### PR TITLE
Port stale failed-state reconciliation from codex

### DIFF
--- a/src/core/supervisor.ts
+++ b/src/core/supervisor.ts
@@ -929,10 +929,16 @@ async function reconcileStaleFailedIssueStates(
   config: SupervisorConfig,
   issues: GitHubIssue[],
 ): Promise<void> {
+  const MAX_RECOVERIES_PER_RUN = 10;
   let changed = false;
+  let recoveredCount = 0;
   const issueStateByNumber = new Map(issues.map((issue) => [issue.number, issue.state ?? null]));
 
   for (const record of Object.values(state.issues)) {
+    if (recoveredCount >= MAX_RECOVERIES_PER_RUN) {
+      break;
+    }
+
     if (record.state !== "failed" || record.pr_number === null) {
       continue;
     }
@@ -966,6 +972,7 @@ async function reconcileStaleFailedIssueStates(
       repeated_failure_signature_count: 0,
       timeout_retry_count: 0,
       blocked_verification_retry_count: 0,
+      // Keep historical attempt_count for observability and per-issue budgeting.
       pr_number: pr.number,
       last_head_sha: pr.headRefOid,
       ...syncReviewWaitWindow(record, pr),
@@ -974,6 +981,7 @@ async function reconcileStaleFailedIssueStates(
     const updated = stateStore.touch(record, patch);
     state.issues[String(record.issue_number)] = updated;
     changed = true;
+    recoveredCount += 1;
   }
 
   if (changed) {


### PR DESCRIPTION
## Summary
Port stale failed-state reconciliation behavior from `codex-supervisor` to reduce remaining state-machine parity gaps.

## What Changed
- Added `reconcileStaleFailedIssueStates(...)` in supervisor:
  - Scans tracked records in `state: failed` with an associated PR.
  - If issue is still open and PR is open, recomputes state from latest checks/review threads.
  - Auto-recovers failed records to a non-terminal actionable state when appropriate.
  - Resets stale failure metadata/retry counters on recovery.
- Updated reconciliation orchestration order to codex parity in `runOnce`:
  1. `reconcileTrackedMergedButOpenIssues`
  2. `reconcileMergedIssueClosures`
  3. `reconcileStaleFailedIssueStates`
  4. `reconcileParentEpicClosures`
- Updated `reconcileParentEpicClosures` to reuse preloaded `issues` (avoid redundant `listAllIssues()` call) and use deterministic `doneResetPatch` + `needsRecordUpdate` semantics.

## Why
This closes an important reliability gap where `failed` records could remain stale even after PR/check/review conditions became healthy, requiring manual intervention unnecessarily.

## Verification Commands Run
- `npm run build --silent`
- `npm run typecheck --silent`
- `npm run test --silent`

## Risks / Known Gaps
- Reconciliation performs additional GitHub reads for eligible failed records.
- Integration-level tests for these reconciliation edge cases are still pending.

## Rollback Plan
- Revert commit `7f83421`.
- If partial rollback needed:
  - Remove `reconcileStaleFailedIssueStates` and restore previous `runOnce` reconciliation order.
  - Restore old `reconcileParentEpicClosures` signature/behavior.
