### PR TITLE
P0: Harden command execution and config validation parity

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,13 +1,37 @@
 import fs from "node:fs";
 import path from "node:path";
 import { AgentCategory, ReasoningEffort, RunState, SupervisorConfig } from "../types";
-import { resolveMaybeRelative } from "../utils";
+import { isValidGitRefName, parseJson, resolveMaybeRelative } from "../utils";
 
 const DEFAULT_CONFIG_FILE = "supervisor.config.json";
 
 function assertString(value: unknown, label: string): string {
   if (typeof value !== "string" || value.trim() === "") {
     throw new Error(`Missing or invalid config field: ${label}`);
+  }
+
+  return value;
+}
+
+function assertPattern(value: string, label: string, pattern: RegExp): string {
+  if (!pattern.test(value)) {
+    throw new Error(`Invalid config field: ${label}`);
+  }
+
+  return value;
+}
+
+function assertGitRefName(value: string, label: string): string {
+  if (!isValidGitRefName(value)) {
+    throw new Error(`Invalid config field: ${label}`);
+  }
+
+  return value;
+}
+
+function assertBranchPrefix(value: string, label: string): string {
+  if (!isValidGitRefName(`${value}1`)) {
+    throw new Error(`Invalid config field: ${label}`);
   }
 
   return value;
@@ -113,7 +137,7 @@ export function loadConfig(configPath?: string): SupervisorConfig {
     throw new Error(`Config file not found: ${resolvedPath}`);
   }
 
-  const raw = JSON.parse(fs.readFileSync(resolvedPath, "utf8")) as Record<string, unknown>;
+  const raw = parseJson<Record<string, unknown>>(fs.readFileSync(resolvedPath, "utf8"), resolvedPath);
   const configDir = path.dirname(resolvedPath);
 
   // Parse agent category mapping
@@ -128,8 +152,8 @@ export function loadConfig(configPath?: string): SupervisorConfig {
 
   const config: SupervisorConfig = {
     repoPath: resolveMaybeRelative(configDir, assertString(raw.repoPath, "repoPath")),
-    repoSlug: assertString(raw.repoSlug, "repoSlug"),
-    defaultBranch: assertString(raw.defaultBranch, "defaultBranch"),
+    repoSlug: assertPattern(assertString(raw.repoSlug, "repoSlug"), "repoSlug", /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/),
+    defaultBranch: assertGitRefName(assertString(raw.defaultBranch, "defaultBranch"), "defaultBranch"),
     workspaceRoot: resolveMaybeRelative(configDir, assertString(raw.workspaceRoot, "workspaceRoot")),
     stateBackend:
       raw.stateBackend === "sqlite" || raw.stateBackend === "json"
@@ -189,7 +213,7 @@ export function loadConfig(configPath?: string): SupervisorConfig {
     skipTitlePrefixes: Array.isArray(raw.skipTitlePrefixes)
       ? raw.skipTitlePrefixes.filter((value): value is string => typeof value === "string")
       : [],
-    branchPrefix: assertString(raw.branchPrefix, "branchPrefix"),
+    branchPrefix: assertBranchPrefix(assertString(raw.branchPrefix, "branchPrefix"), "branchPrefix"),
     pollIntervalSeconds:
       typeof raw.pollIntervalSeconds === "number" && raw.pollIntervalSeconds > 0
         ? raw.pollIntervalSeconds

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -33,6 +33,27 @@ export async function runCommand(
     let timeoutHandle: NodeJS.Timeout | undefined;
     let killHandle: NodeJS.Timeout | undefined;
     let settled = false;
+    let timedOut = false;
+
+    const settleReject = (error: Error): void => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimers();
+      reject(error);
+    };
+
+    const settleResolve = (result: CommandResult): void => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimers();
+      resolve(result);
+    };
 
     const clearTimers = (): void => {
       if (timeoutHandle) {
@@ -51,10 +72,17 @@ export async function runCommand(
       stderr += chunk.toString();
     });
 
-    child.on("error", reject);
+    child.on("error", (error) => {
+      settleReject(new Error(`Failed to spawn command: ${command}`, { cause: error }));
+    });
 
     if (typeof options.timeoutMs === "number") {
       timeoutHandle = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+
+        timedOut = true;
         const pid = child.pid;
         const timeoutMessage = `Command timed out after ${options.timeoutMs}ms: ${command} ${args.join(" ")}`;
         stderr += `${stderr.endsWith("\n") || stderr.length === 0 ? "" : "\n"}${timeoutMessage}\n`;
@@ -87,12 +115,43 @@ export async function runCommand(
       }, options.timeoutMs);
     }
 
-    child.on("close", (code) => {
-      settled = true;
-      clearTimers();
+    child.on("close", (code, signal) => {
+      if (settled) {
+        return;
+      }
+
       const exitCode = code ?? 1;
+      if (timedOut) {
+        settleReject(
+          new Error(
+            [
+              `Command timed out: ${command} ${args.join(" ")}`,
+              `exitCode=${exitCode}`,
+              stderr.trim(),
+            ]
+              .filter(Boolean)
+              .join("\n"),
+          ),
+        );
+        return;
+      }
+
+      if (signal) {
+        settleReject(
+          new Error(
+            [
+              `Command terminated by signal ${signal}: ${command} ${args.join(" ")}`,
+              stderr.trim(),
+            ]
+              .filter(Boolean)
+              .join("\n"),
+          ),
+        );
+        return;
+      }
+
       if (!allowExitCodes.includes(exitCode)) {
-        reject(
+        settleReject(
           new Error(
             [
               `Command failed: ${command} ${args.join(" ")}`,
@@ -106,7 +165,7 @@ export async function runCommand(
         return;
       }
 
-      resolve({ exitCode, stdout, stderr });
+      settleResolve({ exitCode, stdout, stderr });
     });
   });
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -54,6 +54,39 @@ export function resolveMaybeRelative(baseDir: string, inputPath: string): string
   return path.isAbsolute(inputPath) ? inputPath : path.resolve(baseDir, inputPath);
 }
 
+export function parseJson<T>(raw: string, source: string): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse JSON from ${source}: ${message}`, { cause: error });
+  }
+}
+
+export function isValidGitRefName(ref: string): boolean {
+  if (
+    ref.trim() === "" ||
+    ref.startsWith("-") ||
+    ref.startsWith("/") ||
+    ref.endsWith("/") ||
+    ref.endsWith(".") ||
+    ref.includes("..") ||
+    ref.includes("@{") ||
+    ref.includes("\\") ||
+    ref.includes("//")
+  ) {
+    return false;
+  }
+
+  if (/[\u0000-\u001F\u007F ~^:?*\[]/.test(ref)) {
+    return false;
+  }
+
+  return ref
+    .split("/")
+    .every((segment) => segment !== "" && segment !== "." && segment !== ".." && !segment.endsWith(".lock"));
+}
+
 export function hoursSince(isoTimestamp: string): number {
   const timestampMs = Date.parse(isoTimestamp);
   if (Number.isNaN(timestampMs)) {

--- a/test/hardening-parity.test.ts
+++ b/test/hardening-parity.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { loadConfig } from "../src/core/config";
+import { runCommand } from "../src/utils/command";
+
+const BASE_CONFIG = {
+  repoPath: "/tmp/repo",
+  repoSlug: "owner/repo",
+  defaultBranch: "main",
+  workspaceRoot: "/tmp/workspaces",
+  stateFile: "/tmp/state.json",
+  branchPrefix: "opencode/issue-",
+};
+
+async function withTempConfig(
+  payload: string,
+  run: (configPath: string) => Promise<void> | void,
+): Promise<void> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-config-test-"));
+  const configPath = path.join(tempDir, "supervisor.config.json");
+  try {
+    await fs.writeFile(configPath, payload, "utf8");
+    await run(configPath);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("loadConfig rejects invalid repoSlug with field-specific error", async () => {
+  await withTempConfig(
+    JSON.stringify({ ...BASE_CONFIG, repoSlug: "invalid" }),
+    (configPath) => {
+      assert.throws(() => loadConfig(configPath), /Invalid config field: repoSlug/);
+    },
+  );
+});
+
+test("loadConfig rejects invalid defaultBranch with field-specific error", async () => {
+  await withTempConfig(
+    JSON.stringify({ ...BASE_CONFIG, defaultBranch: "feature..bad" }),
+    (configPath) => {
+      assert.throws(() => loadConfig(configPath), /Invalid config field: defaultBranch/);
+    },
+  );
+});
+
+test("loadConfig rejects invalid branchPrefix with field-specific error", async () => {
+  await withTempConfig(
+    JSON.stringify({ ...BASE_CONFIG, branchPrefix: "bad prefix" }),
+    (configPath) => {
+      assert.throws(() => loadConfig(configPath), /Invalid config field: branchPrefix/);
+    },
+  );
+});
+
+test("loadConfig surfaces JSON parse diagnostics with source path context", async () => {
+  await withTempConfig(
+    "{\"repoPath\":\"/tmp/repo\",",
+    (configPath) => {
+      assert.throws(
+        () => loadConfig(configPath),
+        (error: unknown) => {
+          assert.ok(error instanceof Error);
+          assert.match(error.message, new RegExp(`^Failed to parse JSON from ${configPath.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}:`));
+          return true;
+        },
+      );
+    },
+  );
+});
+
+test("runCommand classifies timeout failures deterministically", async () => {
+  await assert.rejects(
+    () => runCommand("node", ["-e", "setTimeout(() => {}, 500)"], { timeoutMs: 50 }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /^Command timed out: node -e setTimeout\(\(\) => \{\}, 500\)/);
+      return true;
+    },
+  );
+});
+
+test("runCommand classifies signal termination deterministically", async () => {
+  await assert.rejects(
+    () => runCommand("node", ["-e", "setTimeout(() => process.kill(process.pid, 'SIGTERM'), 10)"], { timeoutMs: 2_000 }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /^Command terminated by signal SIGTERM: node -e setTimeout\(\(\) => process\.kill\(process\.pid, 'SIGTERM'\), 10\)/);
+      return true;
+    },
+  );
+});
+
+test("runCommand classifies spawn failures deterministically", async () => {
+  await assert.rejects(
+    () => runCommand("command-that-does-not-exist-opencode", []),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /^Failed to spawn command: command-that-does-not-exist-opencode$/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- harden `runCommand` error classification for timeout, signal termination, and spawn failures with deterministic messages
- add config validation parity for `repoSlug`, `defaultBranch` (git ref), and `branchPrefix` guardrails
- improve config parse diagnostics to include source path context for invalid JSON
- add focused regression tests for each new hardening path

## Verification
- pnpm test -- test/hardening-parity.test.ts
- pnpm -r --if-present lint
- pnpm -r --if-present typecheck
- pnpm -r --if-present test
- pnpm -r --if-present build

Closes #7
