### PR TITLE
Issue #9: Add local-review recommendation/degraded gating parity

### DIFF
--- a/src/core/local-review.ts
+++ b/src/core/local-review.ts
@@ -14,6 +14,7 @@ export interface LocalReviewResult {
   findingsCount: number;
   maxSeverity: LocalReviewSeverity;
   recommendation: "ready" | "changes_requested" | "unknown";
+  degraded: boolean;
   rawOutput: string;
 }
 
@@ -142,6 +143,8 @@ export async function runLocalReview(args: {
     .join("\n")
     .trim();
   const parsed = parseFooter(rawOutput);
+  const degraded = result.exitCode !== 0;
+  const recommendation = degraded ? "unknown" : parsed.recommendation;
   const ranAt = nowIso();
   const dirPath = reviewDir(args.config, args.issue.number);
   await ensureDir(dirPath);
@@ -161,7 +164,8 @@ export async function runLocalReview(args: {
       `- Ran at: ${ranAt}`,
       `- Findings: ${parsed.findingsCount}`,
       `- Max severity: ${parsed.maxSeverity}`,
-      `- Recommendation: ${parsed.recommendation}`,
+      `- Recommendation: ${recommendation}`,
+      `- Degraded: ${degraded ? "yes" : "no"}`,
       "",
       rawOutput,
       "",
@@ -179,6 +183,8 @@ export async function runLocalReview(args: {
         headSha: args.pr.headRefOid,
         ranAt,
         ...parsed,
+        recommendation,
+        degraded,
       },
       null,
       2,
@@ -192,5 +198,7 @@ export async function runLocalReview(args: {
     findingsPath,
     rawOutput,
     ...parsed,
+    recommendation,
+    degraded,
   };
 }

--- a/src/core/supervisor.ts
+++ b/src/core/supervisor.ts
@@ -52,6 +52,8 @@ function createIssueRecord(config: SupervisorConfig, issueNumber: number): Issue
     local_review_run_at: null,
     local_review_max_severity: null,
     local_review_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
     attempt_count: 0,
     timeout_retry_count: 0,
     blocked_verification_retry_count: 0,
@@ -417,6 +419,23 @@ function mergeConditionsSatisfied(pr: GitHubPullRequest, checks: PullRequestChec
   );
 }
 
+export function localReviewBlocksReady(
+  record: Pick<
+    IssueRunRecord,
+    "local_review_head_sha" | "local_review_findings_count" | "local_review_recommendation" | "local_review_degraded"
+  >,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): boolean {
+  return (
+    record.local_review_head_sha === pr.headRefOid &&
+    (
+      record.local_review_recommendation !== "ready" ||
+      record.local_review_findings_count > 0 ||
+      Boolean(record.local_review_degraded)
+    )
+  );
+}
+
 function blockedReasonFromReviewState(
   config: SupervisorConfig,
   reviewThreads: ReviewThread[],
@@ -520,6 +539,10 @@ function inferStateFromPullRequest(
 
   if (pr.isDraft) {
     return "draft_pr";
+  }
+
+  if (localReviewBlocksReady(record, pr)) {
+    return "pr_open";
   }
 
   if (!copilotReviewGraceExpired(record, pr, config)) {
@@ -693,7 +716,7 @@ function formatDetailedStatus(args: {
     `last_failure_kind=${activeRecord.last_failure_kind ?? "none"}`,
     `last_failure_signature=${activeRecord.last_failure_signature ?? "none"}`,
     `retries timeout=${activeRecord.timeout_retry_count} verification=${activeRecord.blocked_verification_retry_count} same_blocker=${activeRecord.repeated_blocker_count} same_failure_signature=${activeRecord.repeated_failure_signature_count}`,
-    `local_review head=${activeRecord.local_review_head_sha ?? "none"} severity=${activeRecord.local_review_max_severity ?? "none"} findings=${activeRecord.local_review_findings_count} ran_at=${activeRecord.local_review_run_at ?? "none"}`,
+    `local_review head=${activeRecord.local_review_head_sha ?? "none"} severity=${activeRecord.local_review_max_severity ?? "none"} findings=${activeRecord.local_review_findings_count} recommendation=${activeRecord.local_review_recommendation ?? "none"} degraded=${activeRecord.local_review_degraded ? "yes" : "no"} ran_at=${activeRecord.local_review_run_at ?? "none"}`,
   ];
 
   if (activeRecord.last_error) {
@@ -1707,7 +1730,18 @@ export class Supervisor {
             local_review_run_at: localReview.ranAt,
             local_review_max_severity: localReview.maxSeverity,
             local_review_findings_count: localReview.findingsCount,
-            last_error: null,
+            local_review_recommendation: localReview.recommendation,
+            local_review_degraded: localReview.degraded,
+            blocked_reason: localReview.recommendation !== "ready" ? "verification" : null,
+            last_error:
+              localReview.recommendation !== "ready"
+                ? truncate(
+                    localReview.degraded
+                      ? "Local review completed in a degraded state. PR will remain draft until local review succeeds cleanly."
+                      : `Local review requested changes (${localReview.findingsCount} actionable findings). PR will remain draft until the branch is updated and re-reviewed.`,
+                    500,
+                  )
+                : null,
           });
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
@@ -1718,6 +1752,9 @@ export class Supervisor {
             local_review_run_at: nowIso(),
             local_review_max_severity: null,
             local_review_findings_count: 0,
+            local_review_recommendation: "unknown",
+            local_review_degraded: true,
+            blocked_reason: "verification",
             last_error: `Local review failed: ${truncate(message, 500) ?? "unknown error"}`,
           });
         }
@@ -1735,6 +1772,7 @@ export class Supervisor {
         configuredBotReviewThreads(this.config, refreshedReviewThreads).length === 0 &&
         (!this.config.humanReviewBlocksMerge || manualReviewThreads(this.config, refreshedReviewThreads).length === 0) &&
         !mergeConflictDetected(refreshedPr) &&
+        !localReviewBlocksReady(record, refreshedPr) &&
         !options.dryRun
       ) {
         await this.github.markPullRequestReady(refreshedPr.number);

--- a/src/persistence/state-store.ts
+++ b/src/persistence/state-store.ts
@@ -30,6 +30,8 @@ function normalizeIssueRecord(value: IssueRunRecord): IssueRunRecord {
     local_review_run_at: value.local_review_run_at ?? null,
     local_review_max_severity: value.local_review_max_severity ?? null,
     local_review_findings_count: value.local_review_findings_count ?? 0,
+    local_review_recommendation: value.local_review_recommendation ?? null,
+    local_review_degraded: value.local_review_degraded ?? false,
     timeout_retry_count: value.timeout_retry_count ?? 0,
     blocked_verification_retry_count: value.blocked_verification_retry_count ?? 0,
     repeated_blocker_count: value.repeated_blocker_count ?? 0,
@@ -146,6 +148,14 @@ export class StateStore {
       local_review_max_severity:
         hasOwn(patch, "local_review_max_severity") ? patch.local_review_max_severity ?? null : record.local_review_max_severity ?? null,
       local_review_findings_count: patch.local_review_findings_count ?? record.local_review_findings_count ?? 0,
+      local_review_recommendation:
+        hasOwn(patch, "local_review_recommendation")
+          ? patch.local_review_recommendation ?? null
+          : record.local_review_recommendation ?? null,
+      local_review_degraded:
+        hasOwn(patch, "local_review_degraded")
+          ? patch.local_review_degraded ?? false
+          : record.local_review_degraded ?? false,
       timeout_retry_count: patch.timeout_retry_count ?? record.timeout_retry_count ?? 0,
       blocked_verification_retry_count:
         patch.blocked_verification_retry_count ?? record.blocked_verification_retry_count ?? 0,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,6 +115,8 @@ export interface IssueRunRecord {
   local_review_run_at: string | null;
   local_review_max_severity: "none" | "low" | "medium" | "high" | null;
   local_review_findings_count: number;
+  local_review_recommendation: "ready" | "changes_requested" | "unknown" | null;
+  local_review_degraded: boolean;
   attempt_count: number;
   timeout_retry_count: number;
   blocked_verification_retry_count: number;

--- a/test/local-review-gating.test.ts
+++ b/test/local-review-gating.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { localReviewBlocksReady } from "../src/core/supervisor";
+
+test("localReviewBlocksReady blocks when recommendation is not ready on current head", () => {
+  const blocked = localReviewBlocksReady(
+    {
+      local_review_head_sha: "abc123",
+      local_review_findings_count: 0,
+      local_review_recommendation: "changes_requested",
+    },
+    {
+      headRefOid: "abc123",
+    },
+  );
+
+  assert.equal(blocked, true);
+});
+
+test("localReviewBlocksReady does not block when recommendation is ready with zero findings", () => {
+  const blocked = localReviewBlocksReady(
+    {
+      local_review_head_sha: "abc123",
+      local_review_findings_count: 0,
+      local_review_recommendation: "ready",
+    },
+    {
+      headRefOid: "abc123",
+    },
+  );
+
+  assert.equal(blocked, false);
+});

--- a/test/state-store.touch.test.ts
+++ b/test/state-store.touch.test.ts
@@ -19,6 +19,8 @@ function makeRecord(): IssueRunRecord {
     local_review_run_at: "2026-03-10T00:01:00.000Z",
     local_review_max_severity: "medium",
     local_review_findings_count: 2,
+    local_review_recommendation: "changes_requested",
+    local_review_degraded: true,
     attempt_count: 3,
     timeout_retry_count: 1,
     blocked_verification_retry_count: 1,
@@ -53,6 +55,8 @@ test("touch preserves existing nullable fields when patch omits keys", () => {
 
   assert.equal(updated.state, "stabilizing");
   assert.equal(updated.local_review_summary_path, record.local_review_summary_path);
+  assert.equal(updated.local_review_recommendation, record.local_review_recommendation);
+  assert.equal(updated.local_review_degraded, record.local_review_degraded);
   assert.equal(updated.blocked_reason, record.blocked_reason);
   assert.equal(updated.last_failure_context?.summary, "failure context");
 });
@@ -63,12 +67,16 @@ test("touch clears nullable fields when patch explicitly sets null", () => {
 
   const updated = store.touch(record, {
     local_review_summary_path: null,
+    local_review_recommendation: null,
+    local_review_degraded: false,
     blocked_reason: null,
     last_failure_context: null,
     last_failure_signature: null,
   });
 
   assert.equal(updated.local_review_summary_path, null);
+  assert.equal(updated.local_review_recommendation, null);
+  assert.equal(updated.local_review_degraded, false);
   assert.equal(updated.blocked_reason, null);
   assert.equal(updated.last_failure_context, null);
   assert.equal(updated.last_failure_signature, null);


### PR DESCRIPTION
## Summary
- add `local_review_recommendation` and `local_review_degraded` to issue run records and state-store normalization/touch
- persist recommendation/degraded from local-review success and failure paths
- gate draft->ready and ready->merge flow with explicit local-review recommendation/degraded checks
- include recommendation/degraded in supervisor status output
- add focused tests for local-review gating and state-store persistence

## Verification
- pnpm test -- test/local-review-gating.test.ts test/state-store.touch.test.ts
- pnpm -r --if-present lint
- pnpm -r --if-present typecheck
- pnpm -r --if-present test
- pnpm -r --if-present build

Closes #9
