### PR TITLE
Issue #10: Add maxDoneWorkspaces cleanup parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ See `supervisor.config.example.json` for all available options:
 | `agentCategoryByState` | Map states to agent categories | See example |
 | `pollIntervalSeconds` | Loop interval in seconds | `120` |
 | `maxAgentAttemptsPerIssue` | Max retries per issue | `30` |
+| `maxDoneWorkspaces` | Max retained done workspaces (`<0` disables cap) | `24` |
+| `cleanupDoneWorkspacesAfterHours` | Time-based done workspace cleanup in hours (`<0` disables age cleanup) | `24` |
 | `mergeMethod` | `merge`, `squash`, or `rebase` | `squash` |
 
 ## How It Works

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -246,8 +246,12 @@ export function loadConfig(configPath?: string): SupervisorConfig {
       typeof raw.sameFailureSignatureRepeatLimit === "number" && raw.sameFailureSignatureRepeatLimit >= 0
         ? raw.sameFailureSignatureRepeatLimit
         : 3,
+    maxDoneWorkspaces:
+      typeof raw.maxDoneWorkspaces === "number" && Number.isFinite(raw.maxDoneWorkspaces)
+        ? raw.maxDoneWorkspaces
+        : 24,
     cleanupDoneWorkspacesAfterHours:
-      typeof raw.cleanupDoneWorkspacesAfterHours === "number" && raw.cleanupDoneWorkspacesAfterHours >= 0
+      typeof raw.cleanupDoneWorkspacesAfterHours === "number" && Number.isFinite(raw.cleanupDoneWorkspacesAfterHours)
         ? raw.cleanupDoneWorkspacesAfterHours
         : 24,
     mergeMethod:

--- a/src/core/supervisor.ts
+++ b/src/core/supervisor.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import fsSync from "node:fs";
 import { constants as fsConstants } from "node:fs";
 import path from "node:path";
 import { buildAgentPrompt, extractBlockedReason, extractFailureSignature, extractStateHint, resolveAgentExecutionPolicy, runAgentTurn } from "../agent/agent";
@@ -765,21 +766,63 @@ async function cleanupExpiredDoneWorkspaces(
   config: SupervisorConfig,
   state: SupervisorStateFile,
 ): Promise<void> {
-  if (config.cleanupDoneWorkspacesAfterHours < 0) {
-    return;
-  }
+  const recordsToCleanup = selectDoneWorkspaceCleanupRecords(config, state);
 
-  for (const record of Object.values(state.issues)) {
-    if (record.state !== "done") {
-      continue;
-    }
-
-    if (hoursSince(record.updated_at) < config.cleanupDoneWorkspacesAfterHours) {
-      continue;
-    }
-
+  for (const record of recordsToCleanup) {
     await cleanupWorkspace(config.repoPath, record.workspace, record.branch);
   }
+}
+
+export function selectDoneWorkspaceCleanupRecords(
+  config: SupervisorConfig,
+  state: SupervisorStateFile,
+  options?: {
+    workspaceExists?: (workspacePath: string) => boolean;
+    hoursSinceUpdatedAt?: (updatedAt: string) => number;
+  },
+): IssueRunRecord[] {
+  const workspaceExists =
+    options?.workspaceExists ?? ((workspacePath: string) => fsSync.existsSync(path.join(workspacePath, ".git")));
+  const hoursSinceUpdatedAt = options?.hoursSinceUpdatedAt ?? hoursSince;
+
+  if (config.cleanupDoneWorkspacesAfterHours < 0 && config.maxDoneWorkspaces < 0) {
+    return [];
+  }
+
+  const doneRecords = Object.values(state.issues)
+    .filter((record) => record.state === "done")
+    .sort((left, right) => left.updated_at.localeCompare(right.updated_at));
+
+  const existingDoneRecords = doneRecords.filter((record) => workspaceExists(record.workspace));
+  const recordsToCleanup: IssueRunRecord[] = [];
+  const queuedWorkspaces = new Set<string>();
+
+  if (config.maxDoneWorkspaces >= 0 && existingDoneRecords.length > config.maxDoneWorkspaces) {
+    const overflowCount = existingDoneRecords.length - config.maxDoneWorkspaces;
+    for (const record of existingDoneRecords.slice(0, overflowCount)) {
+      recordsToCleanup.push(record);
+      queuedWorkspaces.add(record.workspace);
+    }
+  }
+
+  if (config.cleanupDoneWorkspacesAfterHours < 0) {
+    return recordsToCleanup;
+  }
+
+  for (const record of doneRecords) {
+    if (queuedWorkspaces.has(record.workspace)) {
+      continue;
+    }
+
+    if (hoursSinceUpdatedAt(record.updated_at) < config.cleanupDoneWorkspacesAfterHours) {
+      continue;
+    }
+
+    recordsToCleanup.push(record);
+    queuedWorkspaces.add(record.workspace);
+  }
+
+  return recordsToCleanup;
 }
 
 function doneResetPatch(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,6 +62,7 @@ export interface SupervisorConfig {
   blockedVerificationRetryLimit: number;
   sameBlockerRepeatLimit: number;
   sameFailureSignatureRepeatLimit: number;
+  maxDoneWorkspaces: number;
   cleanupDoneWorkspacesAfterHours: number;
   mergeMethod: "merge" | "squash" | "rebase";
   draftPrAfterAttempt: number;

--- a/supervisor.config.example.json
+++ b/supervisor.config.example.json
@@ -60,6 +60,7 @@
   "blockedVerificationRetryLimit": 3,
   "sameBlockerRepeatLimit": 2,
   "sameFailureSignatureRepeatLimit": 3,
+  "maxDoneWorkspaces": 24,
   "cleanupDoneWorkspacesAfterHours": 24,
   "mergeMethod": "squash",
   "draftPrAfterAttempt": 1

--- a/test/agent-policy.test.ts
+++ b/test/agent-policy.test.ts
@@ -38,6 +38,7 @@ function makeConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig
     blockedVerificationRetryLimit: 3,
     sameBlockerRepeatLimit: 2,
     sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
     cleanupDoneWorkspacesAfterHours: 24,
     mergeMethod: "squash",
     draftPrAfterAttempt: 1,

--- a/test/done-workspace-cleanup.test.ts
+++ b/test/done-workspace-cleanup.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { selectDoneWorkspaceCleanupRecords } from "../src/core/supervisor";
+import { IssueRunRecord, SupervisorConfig, SupervisorStateFile } from "../src/types";
+
+function makeConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return {
+    repoPath: "/tmp/repo",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "/tmp/workspaces",
+    stateBackend: "json",
+    stateFile: "/tmp/state.json",
+    agentCategoryByState: {
+      implementing: "quick",
+      resolving_conflict: "ultrabrain",
+    },
+    reasoningEffortByState: {
+      implementing: "xhigh",
+      resolving_conflict: "none",
+    },
+    reasoningEscalateOnRepeatedFailure: true,
+    sharedMemoryFiles: [],
+    localReviewEnabled: false,
+    localReviewRoles: ["reviewer"],
+    localReviewArtifactDir: "/tmp/reviews",
+    reviewBotLogins: [],
+    humanReviewBlocksMerge: true,
+    issueJournalRelativePath: ".opencode-supervisor/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    skipTitlePrefixes: [],
+    branchPrefix: "opencode/issue-",
+    pollIntervalSeconds: 120,
+    copilotReviewWaitMinutes: 10,
+    agentExecTimeoutMinutes: 30,
+    maxAgentAttemptsPerIssue: 30,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+    ...overrides,
+  };
+}
+
+function makeDoneRecord(issueNumber: number, updatedAt: string): IssueRunRecord {
+  return {
+    issue_number: issueNumber,
+    state: "done",
+    branch: `opencode/issue-${issueNumber}`,
+    pr_number: null,
+    workspace: `/tmp/workspaces/issue-${issueNumber}`,
+    journal_path: null,
+    review_wait_started_at: null,
+    review_wait_head_sha: null,
+    agent_session_id: null,
+    local_review_head_sha: null,
+    local_review_summary_path: null,
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    attempt_count: 0,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+    last_head_sha: null,
+    last_agent_summary: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: null,
+    blocked_reason: null,
+    processed_review_thread_ids: [],
+    updated_at: updatedAt,
+  };
+}
+
+function makeState(records: IssueRunRecord[]): SupervisorStateFile {
+  return {
+    activeIssueNumber: null,
+    issues: Object.fromEntries(records.map((record) => [String(record.issue_number), record])),
+  };
+}
+
+test("selectDoneWorkspaceCleanupRecords prunes oldest overflow done workspaces first", () => {
+  const state = makeState([
+    makeDoneRecord(1, "2026-03-08T00:00:00.000Z"),
+    makeDoneRecord(2, "2026-03-09T00:00:00.000Z"),
+    makeDoneRecord(3, "2026-03-10T00:00:00.000Z"),
+  ]);
+  const config = makeConfig({
+    maxDoneWorkspaces: 1,
+    cleanupDoneWorkspacesAfterHours: -1,
+  });
+
+  const records = selectDoneWorkspaceCleanupRecords(config, state, {
+    workspaceExists: () => true,
+  });
+
+  assert.deepEqual(
+    records.map((record) => record.issue_number),
+    [1, 2],
+  );
+});
+
+test("selectDoneWorkspaceCleanupRecords enforces zero cap by cleaning all existing done workspaces", () => {
+  const state = makeState([
+    makeDoneRecord(1, "2026-03-08T00:00:00.000Z"),
+    makeDoneRecord(2, "2026-03-09T00:00:00.000Z"),
+    makeDoneRecord(3, "2026-03-10T00:00:00.000Z"),
+  ]);
+  const config = makeConfig({
+    maxDoneWorkspaces: 0,
+    cleanupDoneWorkspacesAfterHours: -1,
+  });
+
+  const records = selectDoneWorkspaceCleanupRecords(config, state, {
+    workspaceExists: (workspacePath) => !workspacePath.endsWith("/issue-2"),
+  });
+
+  assert.deepEqual(
+    records.map((record) => record.issue_number),
+    [1, 3],
+  );
+});
+
+test("selectDoneWorkspaceCleanupRecords disables count pruning when maxDoneWorkspaces is negative", () => {
+  const state = makeState([
+    makeDoneRecord(1, "2026-03-08T00:00:00.000Z"),
+    makeDoneRecord(2, "2026-03-09T00:00:00.000Z"),
+    makeDoneRecord(3, "2026-03-10T00:00:00.000Z"),
+  ]);
+  const config = makeConfig({
+    maxDoneWorkspaces: -1,
+    cleanupDoneWorkspacesAfterHours: 24,
+  });
+
+  const ageByUpdatedAt = new Map([
+    ["2026-03-08T00:00:00.000Z", 96],
+    ["2026-03-09T00:00:00.000Z", 4],
+    ["2026-03-10T00:00:00.000Z", 80],
+  ]);
+  const records = selectDoneWorkspaceCleanupRecords(config, state, {
+    workspaceExists: () => true,
+    hoursSinceUpdatedAt: (updatedAt) => ageByUpdatedAt.get(updatedAt) ?? 0,
+  });
+
+  assert.deepEqual(
+    records.map((record) => record.issue_number),
+    [1, 3],
+  );
+});
+
+test("selectDoneWorkspaceCleanupRecords skips cleanup when both retention rules are disabled", () => {
+  const state = makeState([
+    makeDoneRecord(1, "2026-03-08T00:00:00.000Z"),
+    makeDoneRecord(2, "2026-03-09T00:00:00.000Z"),
+  ]);
+  const config = makeConfig({
+    maxDoneWorkspaces: -1,
+    cleanupDoneWorkspacesAfterHours: -1,
+  });
+
+  const records = selectDoneWorkspaceCleanupRecords(config, state, {
+    workspaceExists: () => true,
+  });
+
+  assert.deepEqual(records, []);
+});

--- a/test/hardening-parity.test.ts
+++ b/test/hardening-parity.test.ts
@@ -104,3 +104,35 @@ test("runCommand classifies spawn failures deterministically", async () => {
     },
   );
 });
+
+test("loadConfig defaults done-workspace retention controls", async () => {
+  await withTempConfig(
+    JSON.stringify(BASE_CONFIG),
+    (configPath) => {
+      const config = loadConfig(configPath) as unknown as {
+        maxDoneWorkspaces: number;
+        cleanupDoneWorkspacesAfterHours: number;
+      };
+      assert.equal(config.maxDoneWorkspaces, 24);
+      assert.equal(config.cleanupDoneWorkspacesAfterHours, 24);
+    },
+  );
+});
+
+test("loadConfig keeps explicit done-workspace retention boundary values", async () => {
+  await withTempConfig(
+    JSON.stringify({
+      ...BASE_CONFIG,
+      maxDoneWorkspaces: 0,
+      cleanupDoneWorkspacesAfterHours: -1,
+    }),
+    (configPath) => {
+      const config = loadConfig(configPath) as unknown as {
+        maxDoneWorkspaces: number;
+        cleanupDoneWorkspacesAfterHours: number;
+      };
+      assert.equal(config.maxDoneWorkspaces, 0);
+      assert.equal(config.cleanupDoneWorkspacesAfterHours, -1);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add `maxDoneWorkspaces` config with finite-number validation and default
- enforce done-workspace cleanup by count cap (oldest first) plus existing time retention
- add focused tests for overflow ordering and `0`/positive/negative semantics

## Verification
- pnpm -r --if-present lint
- pnpm -r --if-present typecheck
- pnpm -r --if-present test
- pnpm -r --if-present build

Closes #10
