### PR TITLE
Add GSD integration parity for config, status, and prompt context

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ See `supervisor.config.example.json` for all available options:
 | `issueLabel` | Label to filter issues | `opencode` |
 | `branchPrefix` | Prefix for issue branches | `opencode/issue-` |
 | `agentCategoryByState` | Map states to agent categories | See example |
+| `gsdEnabled` | Enable GSD planning-file guidance in agent prompts/status | `false` |
+| `gsdAutoInstall` | Auto-install GSD skills when enabled | `false` |
+| `gsdInstallScope` | GSD install scope: `global` or `local` | `global` |
+| `gsdCodexConfigDir` | Optional override for Codex config directory used by GSD | unset |
+| `gsdPlanningFiles` | Planning files treated as upstream intent documents | `PROJECT.md, REQUIREMENTS.md, ROADMAP.md, STATE.md` |
 | `pollIntervalSeconds` | Loop interval in seconds | `120` |
 | `maxAgentAttemptsPerIssue` | Max retries per issue | `30` |
 | `maxDoneWorkspaces` | Max retained done workspaces (`<0` disables cap) | `24` |

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -178,6 +178,8 @@ export function buildAgentPrompt(input: {
   failureContext?: FailureContext | null;
   previousSummary?: string | null;
   previousError?: string | null;
+  gsdEnabled?: boolean;
+  gsdPlanningFiles?: string[];
   category: AgentCategory;
   reasoningEffort: ReasoningEffort;
 }): string {
@@ -270,6 +272,17 @@ export function buildAgentPrompt(input: {
           "- Use the context index to decide whether you need any on-demand durable memory files.",
           "- Do not bulk-read every durable memory file on every turn.",
           "- Treat these files as the durable cross-thread memory shared by agents, CI, and future sessions.",
+        ]
+      : []),
+    ...(input.gsdEnabled
+      ? [
+          "",
+          "GSD collaboration:",
+          "- This repository may contain get-shit-done planning artifacts.",
+          `- Prefer these GSD planning files when requirements are ambiguous: ${input.gsdPlanningFiles?.join(", ") || "none configured"}.`,
+          "- Treat GSD planning files as upstream intent and phase-definition documents.",
+          "- Do not run GSD execution workflows inside this supervisor turn.",
+          "- If a requirement is still unclear after reading the planning docs, record that gap in the issue journal instead of inventing policy.",
         ]
       : []),
     "",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -4,6 +4,7 @@ import { AgentCategory, ReasoningEffort, RunState, SupervisorConfig } from "../t
 import { isValidGitRefName, parseJson, resolveMaybeRelative } from "../utils";
 
 const DEFAULT_CONFIG_FILE = "supervisor.config.json";
+const DEFAULT_GSD_PLANNING_FILES = ["PROJECT.md", "REQUIREMENTS.md", "ROADMAP.md", "STATE.md"];
 
 function assertString(value: unknown, label: string): string {
   if (typeof value !== "string" || value.trim() === "") {
@@ -180,6 +181,25 @@ export function loadConfig(configPath?: string): SupervisorConfig {
     sharedMemoryFiles: Array.isArray(raw.sharedMemoryFiles)
       ? raw.sharedMemoryFiles.filter((value): value is string => typeof value === "string")
       : [],
+    gsdEnabled:
+      typeof raw.gsdEnabled === "boolean"
+        ? raw.gsdEnabled
+        : false,
+    gsdAutoInstall:
+      typeof raw.gsdAutoInstall === "boolean"
+        ? raw.gsdAutoInstall
+        : false,
+    gsdInstallScope:
+      raw.gsdInstallScope === "local" || raw.gsdInstallScope === "global"
+        ? raw.gsdInstallScope
+        : "global",
+    gsdCodexConfigDir:
+      typeof raw.gsdCodexConfigDir === "string" && raw.gsdCodexConfigDir.trim() !== ""
+        ? resolveMaybeRelative(configDir, raw.gsdCodexConfigDir)
+        : undefined,
+    gsdPlanningFiles: Array.isArray(raw.gsdPlanningFiles)
+      ? raw.gsdPlanningFiles.filter((value): value is string => typeof value === "string" && value.trim() !== "")
+      : DEFAULT_GSD_PLANNING_FILES,
     localReviewEnabled:
       typeof raw.localReviewEnabled === "boolean"
         ? raw.localReviewEnabled

--- a/src/core/gsd.ts
+++ b/src/core/gsd.ts
@@ -1,0 +1,20 @@
+import { SupervisorConfig } from "../types";
+
+export function summarizeGsdIntegration(config: Pick<SupervisorConfig, "gsdEnabled" | "gsdAutoInstall" | "gsdInstallScope" | "gsdPlanningFiles" | "gsdCodexConfigDir">): string {
+  if (!config.gsdEnabled) {
+    return "gsd=disabled";
+  }
+
+  const parts = [
+    "gsd=enabled",
+    `scope=${config.gsdInstallScope}`,
+    `auto_install=${config.gsdAutoInstall ? "yes" : "no"}`,
+    `planning_files=${config.gsdPlanningFiles.join(",") || "none"}`,
+  ];
+
+  if (config.gsdCodexConfigDir) {
+    parts.push(`config_dir=${config.gsdCodexConfigDir}`);
+  }
+
+  return parts.join(" ");
+}

--- a/src/core/supervisor.ts
+++ b/src/core/supervisor.ts
@@ -12,6 +12,7 @@ import { runCommand } from "../utils/command";
 import { runLocalReview, shouldRunLocalReview } from "./local-review";
 import { syncMemoryArtifacts } from "../memory/artifacts";
 import { StateStore } from "../persistence/state-store";
+import { summarizeGsdIntegration } from "./gsd";
 import {
   BlockedReason,
   CliOptions,
@@ -686,7 +687,7 @@ function formatRecentRecord(record: IssueRunRecord | null): string {
   return `#${record.issue_number} state=${record.state} updated_at=${record.updated_at}`;
 }
 
-function formatDetailedStatus(args: {
+export function formatDetailedStatus(args: {
   config: SupervisorConfig;
   activeRecord: IssueRunRecord | null;
   latestRecord: IssueRunRecord | null;
@@ -1184,6 +1185,7 @@ export class Supervisor {
 
   async status(): Promise<string> {
     const state = await this.stateStore.load();
+    const gsdSummary = summarizeGsdIntegration(this.config);
     const activeRecord =
       state.activeIssueNumber !== null ? state.issues[String(state.activeIssueNumber)] ?? null : null;
     let latestRecord: IssueRunRecord | null = null;
@@ -1194,7 +1196,7 @@ export class Supervisor {
     }
 
     if (!activeRecord) {
-      return formatDetailedStatus({
+      return `${gsdSummary}\n${formatDetailedStatus({
         config: this.config,
         activeRecord: null,
         latestRecord,
@@ -1202,7 +1204,7 @@ export class Supervisor {
         pr: null,
         checks: [],
         reviewThreads: [],
-      });
+      })}`;
     }
 
     let pr: GitHubPullRequest | null = null;
@@ -1217,7 +1219,7 @@ export class Supervisor {
       }
     } catch (error) {
         const message = sanitizeStatusValue(error instanceof Error ? error.message : String(error));
-        return `${formatDetailedStatus({
+        return `${gsdSummary}\n${formatDetailedStatus({
           config: this.config,
           activeRecord,
           latestRecord,
@@ -1228,7 +1230,7 @@ export class Supervisor {
       })}\nstatus_warning=${truncate(message, 200)}`;
     }
 
-    return formatDetailedStatus({
+    return `${gsdSummary}\n${formatDetailedStatus({
       config: this.config,
       activeRecord,
       latestRecord,
@@ -1236,7 +1238,7 @@ export class Supervisor {
       pr,
       checks,
       reviewThreads,
-    });
+    })}`;
   }
 
   async runOnce(options: Pick<CliOptions, "dryRun">): Promise<string> {
@@ -1528,6 +1530,8 @@ export class Supervisor {
         failureContext: record.last_failure_context,
         previousSummary: previousAgentSummary,
         previousError,
+        gsdEnabled: this.config.gsdEnabled,
+        gsdPlanningFiles: this.config.gsdPlanningFiles,
         alwaysReadFiles: memoryArtifacts.alwaysReadFiles,
         onDemandMemoryFiles: memoryArtifacts.onDemandFiles,
         category: policy.category,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,11 @@ export interface SupervisorConfig {
   reasoningEffortByState: Partial<Record<RunState, ReasoningEffort>>;
   reasoningEscalateOnRepeatedFailure: boolean;
   sharedMemoryFiles: string[];
+  gsdEnabled: boolean;
+  gsdAutoInstall: boolean;
+  gsdInstallScope: "global" | "local";
+  gsdCodexConfigDir?: string;
+  gsdPlanningFiles: string[];
   localReviewEnabled: boolean;
   localReviewRoles: string[];
   localReviewArtifactDir: string;

--- a/supervisor.config.example.json
+++ b/supervisor.config.example.json
@@ -36,6 +36,16 @@
     "docs/workflow.md",
     "docs/decisions.md"
   ],
+  "gsdEnabled": false,
+  "gsdAutoInstall": false,
+  "gsdInstallScope": "global",
+  "gsdCodexConfigDir": "",
+  "gsdPlanningFiles": [
+    "PROJECT.md",
+    "REQUIREMENTS.md",
+    "ROADMAP.md",
+    "STATE.md"
+  ],
   "localReviewEnabled": false,
   "localReviewRoles": [
     "reviewer",

--- a/test/gsd-integration.test.ts
+++ b/test/gsd-integration.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { buildAgentPrompt } from "../src/agent/agent";
+import { Supervisor } from "../src/core/supervisor";
+
+const BASE_CONFIG = {
+  repoPath: "/tmp/repo",
+  repoSlug: "owner/repo",
+  defaultBranch: "main",
+  workspaceRoot: "/tmp/workspaces",
+  stateFile: "/tmp/state.json",
+  branchPrefix: "opencode/issue-",
+};
+
+async function withTempConfig(
+  payload: Record<string, unknown>,
+  run: (configPath: string) => Promise<void> | void,
+): Promise<void> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-gsd-test-"));
+  const configPath = path.join(tempDir, "supervisor.config.json");
+  const stateDir = path.join(tempDir, ".local");
+  try {
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        ...BASE_CONFIG,
+        repoPath: tempDir,
+        workspaceRoot: path.join(tempDir, "workspaces"),
+        stateFile: path.join(stateDir, "state.json"),
+        ...payload,
+      }),
+      "utf8",
+    );
+    await run(configPath);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("buildAgentPrompt injects GSD guidance when enabled", () => {
+  const prompt = buildAgentPrompt({
+    repoSlug: "owner/repo",
+    issue: {
+      number: 11,
+      title: "Issue title",
+      body: "Issue body",
+      createdAt: "2026-03-11T00:00:00Z",
+      updatedAt: "2026-03-11T00:00:00Z",
+      url: "https://example.invalid/issues/11",
+    },
+    branch: "opencode/issue-11",
+    workspacePath: "/tmp/workspaces/issue-11",
+    state: "reproducing",
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-11/.opencode-supervisor/issue-journal.md",
+    gsdEnabled: true,
+    gsdPlanningFiles: ["PROJECT.md", "STATE.md"],
+    category: "deep",
+    reasoningEffort: "medium",
+  });
+
+  assert.match(prompt, /GSD collaboration:/);
+  assert.match(prompt, /PROJECT\.md, STATE\.md/);
+});
+
+test("buildAgentPrompt omits GSD guidance when disabled", () => {
+  const prompt = buildAgentPrompt({
+    repoSlug: "owner/repo",
+    issue: {
+      number: 11,
+      title: "Issue title",
+      body: "Issue body",
+      createdAt: "2026-03-11T00:00:00Z",
+      updatedAt: "2026-03-11T00:00:00Z",
+      url: "https://example.invalid/issues/11",
+    },
+    branch: "opencode/issue-11",
+    workspacePath: "/tmp/workspaces/issue-11",
+    state: "reproducing",
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-11/.opencode-supervisor/issue-journal.md",
+    gsdEnabled: false,
+    gsdPlanningFiles: ["PROJECT.md", "STATE.md"],
+    category: "deep",
+    reasoningEffort: "medium",
+  });
+
+  assert.doesNotMatch(prompt, /GSD collaboration:/);
+});
+
+test("status output includes explicit disabled GSD status by default", async () => {
+  await withTempConfig({}, async (configPath) => {
+    const supervisor = Supervisor.fromConfig(configPath);
+    const output = await supervisor.status();
+    assert.match(output, /^gsd=disabled/m);
+  });
+});
+
+test("status output includes explicit enabled GSD status details", async () => {
+  await withTempConfig(
+    {
+      gsdEnabled: true,
+      gsdAutoInstall: true,
+      gsdInstallScope: "local",
+      gsdPlanningFiles: ["PROJECT.md", "STATE.md"],
+    },
+    async (configPath) => {
+      const supervisor = Supervisor.fromConfig(configPath);
+      const output = await supervisor.status();
+      assert.match(output, /^gsd=enabled\b/m);
+      assert.match(output, /\bscope=local\b/);
+      assert.match(output, /\bauto_install=yes\b/);
+      assert.match(output, /\bplanning_files=PROJECT\.md,STATE\.md\b/);
+    },
+  );
+});

--- a/test/hardening-parity.test.ts
+++ b/test/hardening-parity.test.ts
@@ -136,3 +136,48 @@ test("loadConfig keeps explicit done-workspace retention boundary values", async
     },
   );
 });
+
+test("loadConfig defaults GSD integration fields to disabled with planning files", async () => {
+  await withTempConfig(
+    JSON.stringify(BASE_CONFIG),
+    (configPath) => {
+      const config = loadConfig(configPath) as unknown as {
+        gsdEnabled: boolean;
+        gsdAutoInstall: boolean;
+        gsdInstallScope: string;
+        gsdPlanningFiles: string[];
+      };
+      assert.equal(config.gsdEnabled, false);
+      assert.equal(config.gsdAutoInstall, false);
+      assert.equal(config.gsdInstallScope, "global");
+      assert.deepEqual(config.gsdPlanningFiles, ["PROJECT.md", "REQUIREMENTS.md", "ROADMAP.md", "STATE.md"]);
+    },
+  );
+});
+
+test("loadConfig parses explicit GSD integration fields and filters planning files", async () => {
+  await withTempConfig(
+    JSON.stringify({
+      ...BASE_CONFIG,
+      gsdEnabled: true,
+      gsdAutoInstall: true,
+      gsdInstallScope: "local",
+      gsdCodexConfigDir: "./.codex",
+      gsdPlanningFiles: ["PROJECT.md", "", 123, "STATE.md"],
+    }),
+    (configPath) => {
+      const config = loadConfig(configPath) as unknown as {
+        gsdEnabled: boolean;
+        gsdAutoInstall: boolean;
+        gsdInstallScope: string;
+        gsdCodexConfigDir?: string;
+        gsdPlanningFiles: string[];
+      };
+      assert.equal(config.gsdEnabled, true);
+      assert.equal(config.gsdAutoInstall, true);
+      assert.equal(config.gsdInstallScope, "local");
+      assert.ok(config.gsdCodexConfigDir?.endsWith(`${path.sep}.codex`));
+      assert.deepEqual(config.gsdPlanningFiles, ["PROJECT.md", "STATE.md"]);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add GSD config surface parity (gsdEnabled, gsdAutoInstall, gsdInstallScope, gsdCodexConfigDir, gsdPlanningFiles)
- surface explicit GSD integration status in supervisor status output
- inject GSD planning-file guidance into agent prompt context when enabled
- add focused tests for config defaults/parsing and enabled/disabled prompt/status behavior

## Verification
- npm test
- npm run typecheck
- npm run build

Closes #11