### PR TITLE
Add GSD auto-install and install-health parity

### DIFF
--- a/src/core/gsd.ts
+++ b/src/core/gsd.ts
@@ -1,20 +1,125 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runCommand } from "../utils/command";
 import { SupervisorConfig } from "../types";
 
-export function summarizeGsdIntegration(config: Pick<SupervisorConfig, "gsdEnabled" | "gsdAutoInstall" | "gsdInstallScope" | "gsdPlanningFiles" | "gsdCodexConfigDir">): string {
+const REQUIRED_GSD_SKILLS = [
+  "gsd-help",
+  "gsd-new-project",
+  "gsd-discuss-phase",
+  "gsd-plan-phase",
+  "gsd-execute-phase",
+  "gsd-verify-work",
+];
+const GSD_PACKAGE_SPEC = "get-shit-done-cc@1.22.4";
+const GSD_INSTALL_TIMEOUT_MS = 300_000;
+
+function resolveCodexConfigDir(config: Pick<SupervisorConfig, "repoPath" | "gsdInstallScope" | "gsdCodexConfigDir">): string {
+  if (config.gsdCodexConfigDir) {
+    return config.gsdCodexConfigDir;
+  }
+
+  if (config.gsdInstallScope === "local") {
+    return path.join(config.repoPath, ".codex");
+  }
+
+  if (process.env.CODEX_HOME && process.env.CODEX_HOME.trim() !== "") {
+    return path.resolve(process.env.CODEX_HOME);
+  }
+
+  return path.join(os.homedir(), ".codex");
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function isGsdInstalled(config: Pick<SupervisorConfig, "gsdEnabled" | "repoPath" | "gsdInstallScope" | "gsdCodexConfigDir">): Promise<boolean> {
+  if (!config.gsdEnabled) {
+    return false;
+  }
+
+  const codexDir = resolveCodexConfigDir(config);
+  for (const skillName of REQUIRED_GSD_SKILLS) {
+    const skillPath = path.join(codexDir, "skills", skillName, "SKILL.md");
+    if (!(await fileExists(skillPath))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export async function ensureGsdInstalled(config: Pick<SupervisorConfig, "gsdEnabled" | "gsdAutoInstall" | "repoPath" | "gsdInstallScope" | "gsdCodexConfigDir">): Promise<string | null> {
+  if (!config.gsdEnabled || !config.gsdAutoInstall) {
+    return null;
+  }
+
+  if (await isGsdInstalled(config)) {
+    return null;
+  }
+
+  const codexDir = resolveCodexConfigDir(config);
+  const args = [
+    GSD_PACKAGE_SPEC,
+    "--codex",
+    config.gsdInstallScope === "local" ? "--local" : "--global",
+  ];
+
+  if (config.gsdInstallScope === "global") {
+    args.push("--config-dir", codexDir);
+  }
+
+  await runCommand("npx", args, {
+    cwd: config.repoPath,
+    env: {
+      ...process.env,
+      CODEX_HOME:
+        config.gsdInstallScope === "global" || config.gsdCodexConfigDir
+          ? codexDir
+          : process.env.CODEX_HOME,
+      CI: "1",
+      npm_config_yes: "true",
+    },
+    timeoutMs: GSD_INSTALL_TIMEOUT_MS,
+  });
+
+  if (!(await isGsdInstalled(config))) {
+    throw new Error(`GSD install completed but required Codex skills were not found under ${codexDir}`);
+  }
+
+  return `Installed GSD Codex skills in ${codexDir}.`;
+}
+
+export function summarizeGsdIntegration(config: Pick<SupervisorConfig, "gsdEnabled" | "gsdAutoInstall" | "repoPath" | "gsdInstallScope" | "gsdPlanningFiles" | "gsdCodexConfigDir">): string {
   if (!config.gsdEnabled) {
     return "gsd=disabled";
   }
 
+  const codexDir = resolveCodexConfigDir(config);
   const parts = [
     "gsd=enabled",
+    `codex_home=${codexDir}`,
     `scope=${config.gsdInstallScope}`,
     `auto_install=${config.gsdAutoInstall ? "yes" : "no"}`,
     `planning_files=${config.gsdPlanningFiles.join(",") || "none"}`,
   ];
 
-  if (config.gsdCodexConfigDir) {
-    parts.push(`config_dir=${config.gsdCodexConfigDir}`);
+  return parts.join(" ");
+}
+
+export async function describeGsdIntegration(config: Pick<SupervisorConfig, "gsdEnabled" | "gsdAutoInstall" | "repoPath" | "gsdInstallScope" | "gsdPlanningFiles" | "gsdCodexConfigDir">): Promise<string> {
+  const summary = summarizeGsdIntegration(config);
+  if (!config.gsdEnabled) {
+    return summary;
   }
 
-  return parts.join(" ");
+  const installed = await isGsdInstalled(config);
+  return `${summary} installed=${installed ? "yes" : "no"}`;
 }

--- a/src/core/supervisor.ts
+++ b/src/core/supervisor.ts
@@ -12,7 +12,7 @@ import { runCommand } from "../utils/command";
 import { runLocalReview, shouldRunLocalReview } from "./local-review";
 import { syncMemoryArtifacts } from "../memory/artifacts";
 import { StateStore } from "../persistence/state-store";
-import { summarizeGsdIntegration } from "./gsd";
+import { describeGsdIntegration } from "./gsd";
 import {
   BlockedReason,
   CliOptions,
@@ -1102,7 +1102,7 @@ export class Supervisor {
   private readonly github: GitHubClient;
   private readonly stateStore: StateStore;
 
-  constructor(private readonly config: SupervisorConfig) {
+  constructor(public readonly config: SupervisorConfig) {
     this.github = new GitHubClient(config);
     this.stateStore = new StateStore(config.stateFile, {
       backend: config.stateBackend,
@@ -1185,7 +1185,7 @@ export class Supervisor {
 
   async status(): Promise<string> {
     const state = await this.stateStore.load();
-    const gsdSummary = summarizeGsdIntegration(this.config);
+    const gsdSummary = await describeGsdIntegration(this.config);
     const activeRecord =
       state.activeIssueNumber !== null ? state.issues[String(state.activeIssueNumber)] ?? null : null;
     let latestRecord: IssueRunRecord | null = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Supervisor } from "./core/supervisor";
+import { ensureGsdInstalled } from "./core/gsd";
 import { CliOptions } from "./types";
 import { sleep } from "./utils";
 
@@ -55,6 +56,13 @@ async function runOnceWithSupervisorLock(
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
   const supervisor = Supervisor.fromConfig(options.configPath);
+
+  if (options.command !== "status") {
+    const installMessage = await ensureGsdInstalled(supervisor.config);
+    if (installMessage) {
+      console.log(installMessage);
+    }
+  }
 
   if (options.command === "status") {
     console.log(await supervisor.status());

--- a/test/gsd-integration.test.ts
+++ b/test/gsd-integration.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { buildAgentPrompt } from "../src/agent/agent";
+import { ensureGsdInstalled } from "../src/core/gsd";
 import { Supervisor } from "../src/core/supervisor";
 
 const BASE_CONFIG = {
@@ -123,6 +124,105 @@ test("status output includes explicit enabled GSD status details", async () => {
       assert.match(output, /\bscope=local\b/);
       assert.match(output, /\bauto_install=yes\b/);
       assert.match(output, /\bplanning_files=PROJECT\.md,STATE\.md\b/);
+      assert.match(output, /\binstalled=no\b/);
+    },
+  );
+});
+
+test("status output reports installed=yes when required GSD skills are present", async () => {
+  await withTempConfig(
+    {
+      gsdEnabled: true,
+      gsdAutoInstall: true,
+      gsdInstallScope: "local",
+      gsdPlanningFiles: ["PROJECT.md", "STATE.md"],
+    },
+    async (configPath) => {
+      const configDir = path.join(path.dirname(configPath), ".codex");
+      for (const skillName of [
+        "gsd-help",
+        "gsd-new-project",
+        "gsd-discuss-phase",
+        "gsd-plan-phase",
+        "gsd-execute-phase",
+        "gsd-verify-work",
+      ]) {
+        await fs.mkdir(path.join(configDir, "skills", skillName), { recursive: true });
+        await fs.writeFile(path.join(configDir, "skills", skillName, "SKILL.md"), `# ${skillName}\n`, "utf8");
+      }
+
+      const supervisor = Supervisor.fromConfig(configPath);
+      const output = await supervisor.status();
+      assert.match(output, /^gsd=enabled\b/m);
+      assert.match(output, /\binstalled=yes\b/);
+    },
+  );
+});
+
+test("ensureGsdInstalled is a no-op when GSD is disabled", async () => {
+  await withTempConfig(
+    {
+      gsdEnabled: false,
+      gsdAutoInstall: true,
+      gsdInstallScope: "local",
+    },
+    async (configPath) => {
+      const supervisor = Supervisor.fromConfig(configPath);
+      const output = await ensureGsdInstalled(supervisor.config);
+      assert.equal(output, null);
+    },
+  );
+});
+
+test("ensureGsdInstalled installs required skills when enabled and missing", async () => {
+  await withTempConfig(
+    {
+      gsdEnabled: true,
+      gsdAutoInstall: true,
+      gsdInstallScope: "local",
+      gsdPlanningFiles: ["PROJECT.md", "STATE.md"],
+    },
+    async (configPath) => {
+      const supervisor = Supervisor.fromConfig(configPath);
+      const binDir = path.join(path.dirname(configPath), "bin");
+      const fakeNpxPath = path.join(binDir, "npx");
+      await fs.mkdir(binDir, { recursive: true });
+      await fs.writeFile(
+        fakeNpxPath,
+        [
+          "#!/usr/bin/env bash",
+          "set -euo pipefail",
+          "codex_dir=\"\"",
+          "args=(\"$@\")",
+          "for ((i=0; i<${#args[@]}; i++)); do",
+          "  if [[ \"${args[$i]}\" == \"--local\" ]]; then",
+          "    codex_dir=\"$PWD/.codex\"",
+          "  fi",
+          "  if [[ \"${args[$i]}\" == \"--config-dir\" ]]; then",
+          "    codex_dir=\"${args[$((i+1))]}\"",
+          "  fi",
+          "done",
+          "mkdir -p \"$codex_dir/skills\"",
+          "for skill in gsd-help gsd-new-project gsd-discuss-phase gsd-plan-phase gsd-execute-phase gsd-verify-work; do",
+          "  mkdir -p \"$codex_dir/skills/$skill\"",
+          "  printf \"# %s\\n\" \"$skill\" > \"$codex_dir/skills/$skill/SKILL.md\"",
+          "done",
+        ].join("\n"),
+        "utf8",
+      );
+      await fs.chmod(fakeNpxPath, 0o755);
+
+      const originalPath = process.env.PATH;
+      process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+      try {
+        const installMessage = await ensureGsdInstalled(supervisor.config);
+        assert.match(installMessage ?? "", /Installed GSD Codex skills/);
+      } finally {
+        process.env.PATH = originalPath;
+      }
+
+      const status = await supervisor.status();
+      assert.match(status, /\binstalled=yes\b/);
     },
   );
 });


### PR DESCRIPTION
## Summary
- add GSD install detection and install-health helpers
- auto-install missing GSD skills at startup when enabled + auto-install
- include install health in status output and add focused enabled/disabled/install-state tests

## Verification
- pnpm -r --if-present lint
- pnpm -r --if-present typecheck
- pnpm -r --if-present test
- pnpm -r --if-present build

Closes #15