### PR TITLE
P5: graceful loop shutdown signal handling parity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,16 +77,47 @@ async function main(): Promise<void> {
     return;
   }
 
-  while (true) {
-    try {
-      const message = await runOnceWithSupervisorLock(supervisor, "loop", { dryRun: options.dryRun });
-      console.log(`${new Date().toISOString()} ${message}`);
-    } catch (error) {
-      const message = error instanceof Error ? error.stack ?? error.message : String(error);
-      console.error(`${new Date().toISOString()} loop-error ${message}`);
+  const sleepAbortController = new AbortController();
+  let shutdownSignal: NodeJS.Signals | null = null;
+  const onShutdownSignal = (signal: NodeJS.Signals): void => {
+    if (shutdownSignal) {
+      return;
     }
+    shutdownSignal = signal;
+    console.log(`${new Date().toISOString()} loop-shutdown requested via ${signal}; exiting after current cycle`);
+    sleepAbortController.abort();
+  };
+  const sigintHandler = (): void => onShutdownSignal("SIGINT");
+  const sigtermHandler = (): void => onShutdownSignal("SIGTERM");
+  process.on("SIGINT", sigintHandler);
+  process.on("SIGTERM", sigtermHandler);
 
-    await sleep(pollIntervalMs);
+  try {
+    while (true) {
+      try {
+        const message = await runOnceWithSupervisorLock(supervisor, "loop", { dryRun: options.dryRun });
+        console.log(`${new Date().toISOString()} ${message}`);
+      } catch (error) {
+        const message = error instanceof Error ? error.stack ?? error.message : String(error);
+        console.error(`${new Date().toISOString()} loop-error ${message}`);
+      }
+
+      if (shutdownSignal) {
+        break;
+      }
+
+      await sleep(pollIntervalMs, { signal: sleepAbortController.signal });
+      if (shutdownSignal) {
+        break;
+      }
+    }
+  } finally {
+    process.off("SIGINT", sigintHandler);
+    process.off("SIGTERM", sigtermHandler);
+  }
+
+  if (shutdownSignal) {
+    console.log(`${new Date().toISOString()} loop-shutdown complete via ${shutdownSignal}`);
   }
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -42,8 +42,37 @@ export async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
   }
 }
 
-export async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, ms));
+export async function sleep(ms: number, options?: { signal?: AbortSignal }): Promise<void> {
+  if (ms <= 0) {
+    return;
+  }
+
+  const signal = options?.signal;
+  if (signal?.aborted) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    let finished = false;
+    const onAbort = (): void => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 export function isTerminalState(state: string): boolean {

--- a/test/loop-shutdown.test.ts
+++ b/test/loop-shutdown.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { once } from "node:events";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+type ChildResult = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  output: string;
+};
+
+async function waitForOutput(buffer: () => string, pattern: RegExp, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pattern.test(buffer())) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for output pattern ${pattern}`);
+}
+
+async function createExecutable(filePath: string, body: string): Promise<void> {
+  await fs.writeFile(filePath, body, { encoding: "utf8", mode: 0o755 });
+}
+
+test("loop mode handles SIGTERM with explicit graceful shutdown output", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-loop-shutdown-"));
+  try {
+    const fakeRepoPath = path.join(tempDir, "repo");
+    const fakeWorkspaceRoot = path.join(tempDir, "workspaces");
+    const fakeStateFile = path.join(tempDir, "state", "supervisor-state.json");
+    const fakeBinDir = path.join(tempDir, "bin");
+    const configPath = path.join(tempDir, "supervisor.config.json");
+
+    await fs.mkdir(path.join(fakeRepoPath, ".git"), { recursive: true });
+    await fs.mkdir(fakeWorkspaceRoot, { recursive: true });
+    await fs.mkdir(fakeBinDir, { recursive: true });
+
+    await createExecutable(path.join(fakeBinDir, "gh"), "#!/usr/bin/env bash\nif [[ \"$1\" == \"auth\" && \"$2\" == \"status\" ]]; then\n  exit 0\nfi\nexit 1\n");
+    await createExecutable(path.join(fakeBinDir, "opencode"), "#!/usr/bin/env bash\nif [[ \"$1\" == \"--version\" ]]; then\n  echo \"opencode-test\"\n  exit 0\nfi\nexit 1\n");
+
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          repoPath: fakeRepoPath,
+          repoSlug: "owner/repo",
+          defaultBranch: "main",
+          workspaceRoot: fakeWorkspaceRoot,
+          stateFile: fakeStateFile,
+          branchPrefix: "opencode/issue-",
+          pollIntervalSeconds: 60,
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const child = spawn(
+      process.execPath,
+      ["--import", "tsx", "src/index.ts", "loop", "--config", configPath],
+      {
+        cwd: path.resolve(__dirname, ".."),
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    let output = "";
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      output += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      output += chunk.toString();
+    });
+
+    await waitForOutput(() => output, /loop-error|Skipped supervisor cycle:/, 10_000);
+    child.kill("SIGTERM");
+    const [code, signal] = (await once(child, "close")) as [number | null, NodeJS.Signals | null];
+    const result: ChildResult = { code, signal, output };
+
+    assert.equal(result.signal, null);
+    assert.equal(result.code, 0);
+    assert.match(result.output, /shutdown requested/i);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary\n- add loop-mode SIGINT/SIGTERM handlers to request graceful shutdown\n- interrupt poll sleep via abortable sleep and exit after current cycle\n- add focused regression test covering SIGTERM loop shutdown behavior\n\n## Verification\n- pnpm -r --if-present lint\n- pnpm -r --if-present typecheck\n- pnpm -r --if-present test\n- pnpm -r --if-present build\n\nCloses #16