### PR TITLE
P6: Add local-review confidence-threshold parity

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -211,6 +211,13 @@ export function loadConfig(configPath?: string): SupervisorConfig {
       typeof raw.localReviewArtifactDir === "string" && raw.localReviewArtifactDir.trim() !== ""
         ? resolveMaybeRelative(configDir, raw.localReviewArtifactDir)
         : path.join(path.dirname(resolveMaybeRelative(configDir, assertString(raw.stateFile, "stateFile"))), "reviews"),
+    localReviewConfidenceThreshold:
+      typeof raw.localReviewConfidenceThreshold === "number" &&
+      Number.isFinite(raw.localReviewConfidenceThreshold) &&
+      raw.localReviewConfidenceThreshold >= 0 &&
+      raw.localReviewConfidenceThreshold <= 1
+        ? raw.localReviewConfidenceThreshold
+        : 0.7,
     reviewBotLogins: Array.isArray(raw.reviewBotLogins)
       ? raw.reviewBotLogins
           .filter((value): value is string => typeof value === "string" && value.trim() !== "")

--- a/src/core/local-review.ts
+++ b/src/core/local-review.ts
@@ -5,6 +5,17 @@ import { GitHubIssue, GitHubPullRequest, SupervisorConfig } from "../types";
 import { ensureDir, nowIso, truncate } from "../utils";
 
 export type LocalReviewSeverity = "none" | "low" | "medium" | "high";
+type ActionableSeverity = Exclude<LocalReviewSeverity, "none">;
+
+export interface LocalReviewFinding {
+  title: string;
+  body: string;
+  severity: ActionableSeverity;
+  confidence: number;
+  file: string | null;
+  start: number | null;
+  end: number | null;
+}
 
 export interface LocalReviewResult {
   ranAt: string;
@@ -26,17 +37,117 @@ function reviewDir(config: SupervisorConfig, issueNumber: number): string {
   return path.join(config.localReviewArtifactDir, safeSlug(config.repoSlug), `issue-${issueNumber}`);
 }
 
-function parseFooter(output: string): Pick<LocalReviewResult, "summary" | "findingsCount" | "maxSeverity" | "recommendation"> {
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function normalizeSeverity(value: unknown): ActionableSeverity | null {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (normalized === "low" || normalized === "medium" || normalized === "high") {
+    return normalized;
+  }
+
+  return null;
+}
+
+function normalizeConfidence(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return Math.max(0, Math.min(1, value));
+}
+
+function normalizeFinding(value: unknown): LocalReviewFinding | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const title = typeof record.title === "string" ? normalizeWhitespace(record.title) : "";
+  const body = typeof record.body === "string" ? normalizeWhitespace(record.body) : "";
+  const severity = normalizeSeverity(record.severity);
+  const confidence = normalizeConfidence(record.confidence);
+  if (!title || !body || !severity || confidence === null) {
+    return null;
+  }
+
+  let start =
+    typeof record.start === "number" && Number.isInteger(record.start) && record.start > 0
+      ? record.start
+      : null;
+  let end =
+    typeof record.end === "number" && Number.isInteger(record.end) && record.end > 0
+      ? record.end
+      : start;
+
+  if (start === null && end !== null) {
+    start = end;
+  }
+
+  return {
+    title,
+    body,
+    severity,
+    confidence,
+    file: typeof record.file === "string" && record.file.trim() !== "" ? record.file.trim() : null,
+    start,
+    end,
+  };
+}
+
+function maxSeverity(findings: Pick<LocalReviewFinding, "severity">[]): LocalReviewSeverity {
+  if (findings.some((finding) => finding.severity === "high")) {
+    return "high";
+  }
+  if (findings.some((finding) => finding.severity === "medium")) {
+    return "medium";
+  }
+  if (findings.some((finding) => finding.severity === "low")) {
+    return "low";
+  }
+
+  return "none";
+}
+
+function parseFooter(output: string): {
+  summary: string;
+  reportedFindingsCount: number;
+  maxSeverity: LocalReviewSeverity;
+  recommendation: LocalReviewResult["recommendation"];
+  findings: LocalReviewFinding[];
+  hasStructuredFindingsPayload: boolean;
+} {
   const summaryMatch = output.match(/Review summary:\s*(.+)/i);
   const findingsMatch = output.match(/Findings count:\s*(\d+)/i);
   const severityMatch = output.match(/Max severity:\s*(none|low|medium|high)/i);
   const recommendationMatch = output.match(/Recommendation:\s*(ready|changes_requested)/i);
+  const jsonMatch = output.match(/REVIEW_FINDINGS_JSON_START\s*([\s\S]*?)\s*REVIEW_FINDINGS_JSON_END/i);
+
+  let findings: LocalReviewFinding[] = [];
+  let hasStructuredFindingsPayload = false;
+
+  if (jsonMatch?.[1]) {
+    try {
+      const parsed = JSON.parse(jsonMatch[1]) as Record<string, unknown>;
+      if (Array.isArray(parsed.findings)) {
+        hasStructuredFindingsPayload = true;
+        findings = parsed.findings
+          .map((item) => normalizeFinding(item))
+          .filter((item): item is LocalReviewFinding => item !== null);
+      }
+    } catch {
+      findings = [];
+    }
+  }
 
   return {
     summary: truncate(summaryMatch?.[1]?.trim() ?? "Local review completed without a structured summary.", 500) ?? "",
-    findingsCount: findingsMatch ? Number.parseInt(findingsMatch[1], 10) : 0,
+    reportedFindingsCount: findingsMatch ? Number.parseInt(findingsMatch[1], 10) : 0,
     maxSeverity: (severityMatch?.[1]?.toLowerCase() as LocalReviewSeverity | undefined) ?? "none",
     recommendation: (recommendationMatch?.[1]?.toLowerCase() as "ready" | "changes_requested" | undefined) ?? "unknown",
+    findings,
+    hasStructuredFindingsPayload,
   };
 }
 
@@ -58,6 +169,7 @@ function buildLocalReviewPrompt(args: {
   roles: string[];
   alwaysReadFiles: string[];
   onDemandFiles: string[];
+  confidenceThreshold: number;
 }): string {
   const compareRef = `origin/${args.defaultBranch}...HEAD`;
   const roleList = args.roles.length > 0 ? args.roles.join(", ") : "reviewer, explorer";
@@ -99,6 +211,14 @@ function buildLocalReviewPrompt(args: {
     `- git diff --stat ${compareRef}`,
     `- git diff ${compareRef}`,
     "",
+    "Structured findings format:",
+    `- Treat findings with confidence >= ${args.confidenceThreshold.toFixed(2)} as actionable.`,
+    "- Include all findings in a JSON object between exact markers:",
+    "  REVIEW_FINDINGS_JSON_START",
+    '  {"findings":[{"title":"...","body":"...","severity":"low|medium|high","confidence":0.0,"file":"path","start":1,"end":1}]}',
+    "  REVIEW_FINDINGS_JSON_END",
+    "- Return an empty findings array when there are no actionable findings.",
+    "",
     "Respond with a concise review and end with this exact footer:",
     "Review summary: <short summary>",
     "Findings count: <integer>",
@@ -127,6 +247,7 @@ export async function runLocalReview(args: {
     roles: args.config.localReviewRoles,
     alwaysReadFiles: args.alwaysReadFiles,
     onDemandFiles: args.onDemandFiles,
+    confidenceThreshold: args.config.localReviewConfidenceThreshold,
   });
 
   const result = await runAgentTurn(
@@ -144,7 +265,25 @@ export async function runLocalReview(args: {
     .trim();
   const parsed = parseFooter(rawOutput);
   const degraded = result.exitCode !== 0;
-  const recommendation = degraded ? "unknown" : parsed.recommendation;
+  const actionableFindings = parsed.findings.filter(
+    (finding) => finding.confidence >= args.config.localReviewConfidenceThreshold,
+  );
+  const useThresholdFiltering = parsed.hasStructuredFindingsPayload;
+  const findingsCount = useThresholdFiltering ? actionableFindings.length : parsed.reportedFindingsCount;
+  const effectiveMaxSeverity = useThresholdFiltering ? maxSeverity(actionableFindings) : parsed.maxSeverity;
+  const recommendation = degraded
+    ? "unknown"
+    : useThresholdFiltering
+      ? findingsCount > 0
+        ? "changes_requested"
+        : "ready"
+      : parsed.recommendation;
+  const summary = useThresholdFiltering
+    ? truncate(
+        `${parsed.summary} Actionable findings above confidence ${args.config.localReviewConfidenceThreshold.toFixed(2)}: ${findingsCount}.`,
+        500,
+      ) ?? ""
+    : parsed.summary;
   const ranAt = nowIso();
   const dirPath = reviewDir(args.config, args.issue.number);
   await ensureDir(dirPath);
@@ -162,8 +301,9 @@ export async function runLocalReview(args: {
       `- Branch: ${args.branch}`,
       `- Head SHA: ${args.pr.headRefOid}`,
       `- Ran at: ${ranAt}`,
-      `- Findings: ${parsed.findingsCount}`,
-      `- Max severity: ${parsed.maxSeverity}`,
+      `- Confidence threshold: ${args.config.localReviewConfidenceThreshold.toFixed(2)}`,
+      `- Actionable findings: ${findingsCount}`,
+      `- Max severity: ${effectiveMaxSeverity}`,
       `- Recommendation: ${recommendation}`,
       `- Degraded: ${degraded ? "yes" : "no"}`,
       "",
@@ -182,7 +322,14 @@ export async function runLocalReview(args: {
         branch: args.branch,
         headSha: args.pr.headRefOid,
         ranAt,
-        ...parsed,
+        confidenceThreshold: args.config.localReviewConfidenceThreshold,
+        summary,
+        reportedFindingsCount: parsed.reportedFindingsCount,
+        findingsCount,
+        actionableFindingsCount: findingsCount,
+        maxSeverity: effectiveMaxSeverity,
+        parsedFindings: parsed.findings,
+        actionableFindings,
         recommendation,
         degraded,
       },
@@ -197,7 +344,9 @@ export async function runLocalReview(args: {
     summaryPath,
     findingsPath,
     rawOutput,
-    ...parsed,
+    summary,
+    findingsCount,
+    maxSeverity: effectiveMaxSeverity,
     recommendation,
     degraded,
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,7 @@ export interface SupervisorConfig {
   localReviewEnabled: boolean;
   localReviewRoles: string[];
   localReviewArtifactDir: string;
+  localReviewConfidenceThreshold: number;
   reviewBotLogins: string[];
   humanReviewBlocksMerge: boolean;
   issueJournalRelativePath: string;

--- a/supervisor.config.example.json
+++ b/supervisor.config.example.json
@@ -53,6 +53,7 @@
     "docs_researcher"
   ],
   "localReviewArtifactDir": "./.local/reviews",
+  "localReviewConfidenceThreshold": 0.7,
   "reviewBotLogins": [
     "copilot-pull-request-reviewer"
   ],

--- a/test/agent-policy.test.ts
+++ b/test/agent-policy.test.ts
@@ -24,6 +24,7 @@ function makeConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig
     localReviewEnabled: false,
     localReviewRoles: ["reviewer"],
     localReviewArtifactDir: "/tmp/reviews",
+    localReviewConfidenceThreshold: 0.7,
     reviewBotLogins: [],
     humanReviewBlocksMerge: true,
     issueJournalRelativePath: ".opencode-supervisor/issue-journal.md",

--- a/test/done-workspace-cleanup.test.ts
+++ b/test/done-workspace-cleanup.test.ts
@@ -24,6 +24,7 @@ function makeConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig
     localReviewEnabled: false,
     localReviewRoles: ["reviewer"],
     localReviewArtifactDir: "/tmp/reviews",
+    localReviewConfidenceThreshold: 0.7,
     reviewBotLogins: [],
     humanReviewBlocksMerge: true,
     issueJournalRelativePath: ".opencode-supervisor/issue-journal.md",

--- a/test/hardening-parity.test.ts
+++ b/test/hardening-parity.test.ts
@@ -181,3 +181,43 @@ test("loadConfig parses explicit GSD integration fields and filters planning fil
     },
   );
 });
+
+test("loadConfig defaults localReviewConfidenceThreshold to 0.7", async () => {
+  await withTempConfig(
+    JSON.stringify(BASE_CONFIG),
+    (configPath) => {
+      const config = loadConfig(configPath) as unknown as {
+        localReviewConfidenceThreshold: number;
+      };
+      assert.equal(config.localReviewConfidenceThreshold, 0.7);
+    },
+  );
+});
+
+test("loadConfig keeps valid localReviewConfidenceThreshold and falls back for invalid values", async () => {
+  await withTempConfig(
+    JSON.stringify({
+      ...BASE_CONFIG,
+      localReviewConfidenceThreshold: 0.9,
+    }),
+    (configPath) => {
+      const config = loadConfig(configPath) as unknown as {
+        localReviewConfidenceThreshold: number;
+      };
+      assert.equal(config.localReviewConfidenceThreshold, 0.9);
+    },
+  );
+
+  await withTempConfig(
+    JSON.stringify({
+      ...BASE_CONFIG,
+      localReviewConfidenceThreshold: 1.1,
+    }),
+    (configPath) => {
+      const config = loadConfig(configPath) as unknown as {
+        localReviewConfidenceThreshold: number;
+      };
+      assert.equal(config.localReviewConfidenceThreshold, 0.7);
+    },
+  );
+});

--- a/test/local-review-threshold.test.ts
+++ b/test/local-review-threshold.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { runLocalReview } from "../src/core/local-review";
+import { GitHubIssue, GitHubPullRequest, SupervisorConfig } from "../src/types";
+
+function makeConfig(artifactDir: string): SupervisorConfig {
+  return {
+    repoPath: "/tmp/repo",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "/tmp/workspaces",
+    stateBackend: "json",
+    stateFile: "/tmp/state.json",
+    agentCategoryByState: {},
+    reasoningEffortByState: {},
+    reasoningEscalateOnRepeatedFailure: true,
+    sharedMemoryFiles: [],
+    gsdEnabled: false,
+    gsdAutoInstall: false,
+    gsdInstallScope: "global",
+    gsdPlanningFiles: ["PROJECT.md", "REQUIREMENTS.md", "ROADMAP.md", "STATE.md"],
+    localReviewEnabled: true,
+    localReviewRoles: ["reviewer"],
+    localReviewArtifactDir: artifactDir,
+    localReviewConfidenceThreshold: 0.7,
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+    humanReviewBlocksMerge: true,
+    issueJournalRelativePath: ".opencode-supervisor/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    skipTitlePrefixes: [],
+    branchPrefix: "opencode/issue-",
+    pollIntervalSeconds: 120,
+    copilotReviewWaitMinutes: 10,
+    agentExecTimeoutMinutes: 30,
+    maxAgentAttemptsPerIssue: 30,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+  };
+}
+
+const ISSUE: GitHubIssue = {
+  number: 17,
+  title: "P6: Add local-review confidence-threshold parity",
+  body: "",
+  url: "https://example.test/issues/17",
+};
+
+const PR: GitHubPullRequest = {
+  number: 42,
+  url: "https://example.test/pull/42",
+  state: "OPEN",
+  isDraft: true,
+  headRefName: "codex/issue-17",
+  headRefOid: "abc123def4567890abc123def4567890abc123de",
+  baseRefName: "main",
+  mergeStateStatus: "CLEAN",
+  reviewDecision: null,
+};
+
+test("runLocalReview filters actionable findings by confidence threshold in artifacts", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-local-review-threshold-"));
+  const priorTask = (globalThis as Record<string, unknown>).task;
+  (globalThis as Record<string, unknown>).task = async () => ({
+    sessionId: "session-1",
+    exitCode: 0,
+    output: [
+      "Review summary: Found 2 findings, only 1 should be actionable.",
+      "Findings count: 2",
+      "Max severity: high",
+      "Recommendation: changes_requested",
+      "REVIEW_FINDINGS_JSON_START",
+      JSON.stringify({
+        findings: [
+          {
+            title: "High confidence defect",
+            body: "This can break in production.",
+            severity: "high",
+            confidence: 0.95,
+            file: "src/core/supervisor.ts",
+            start: 10,
+            end: 10,
+          },
+          {
+            title: "Low confidence concern",
+            body: "This is speculative.",
+            severity: "medium",
+            confidence: 0.25,
+            file: "src/core/supervisor.ts",
+            start: 12,
+            end: 12,
+          },
+        ],
+      }),
+      "REVIEW_FINDINGS_JSON_END",
+    ].join("\n"),
+  });
+
+  try {
+    const config = makeConfig(tempDir) as SupervisorConfig & { localReviewConfidenceThreshold: number };
+
+    const result = await runLocalReview({
+      config,
+      issue: ISSUE,
+      branch: "codex/issue-17",
+      workspacePath: "/tmp/workspace",
+      defaultBranch: "main",
+      pr: PR,
+      alwaysReadFiles: [],
+      onDemandFiles: [],
+    });
+
+    assert.equal(result.findingsCount, 1);
+    assert.equal(result.recommendation, "changes_requested");
+
+    const summary = await fs.readFile(result.summaryPath, "utf8");
+    assert.match(summary, /Confidence threshold:\s+0\.70/);
+    assert.match(summary, /Actionable findings:\s+1/);
+
+    const findings = JSON.parse(await fs.readFile(result.findingsPath, "utf8")) as Record<string, unknown>;
+    assert.equal(findings.confidenceThreshold, 0.7);
+    assert.equal(findings.actionableFindingsCount, 1);
+  } finally {
+    if (typeof priorTask === "undefined") {
+      delete (globalThis as Record<string, unknown>).task;
+    } else {
+      (globalThis as Record<string, unknown>).task = priorTask;
+    }
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add `localReviewConfidenceThreshold` config parity with default and bounds validation
- filter local-review actionable findings by confidence threshold when structured findings are present
- include threshold-aware actionable counts in local-review summary and artifact JSON
- add focused tests for config threshold parsing and local-review threshold filtering

Closes #17

## Verification
- pnpm -r --if-present lint
- pnpm -r --if-present typecheck
- pnpm -r --if-present test
- pnpm -r --if-present build
