### PR TITLE
Parity: rerun local review on ready PR updates and support merge gating (#26)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { AgentCategory, ReasoningEffort, RunState, SupervisorConfig } from "../types";
+import { AgentCategory, LocalReviewPolicy, ReasoningEffort, RunState, SupervisorConfig } from "../types";
 import { isValidGitRefName, parseJson, resolveMaybeRelative } from "../utils";
 
 const DEFAULT_CONFIG_FILE = "supervisor.config.json";
@@ -69,6 +69,7 @@ const VALID_RUN_STATES = new Set<RunState>([
   "blocked",
   "failed",
 ]);
+const VALID_LOCAL_REVIEW_POLICIES = new Set<LocalReviewPolicy>(["advisory", "block_ready", "block_merge"]);
 
 function parseEnumPolicy<T extends string>(
   value: unknown,
@@ -221,6 +222,10 @@ export function loadConfig(configPath?: string): SupervisorConfig {
       raw.localReviewConfidenceThreshold <= 1
         ? raw.localReviewConfidenceThreshold
         : 0.7,
+    localReviewPolicy:
+      typeof raw.localReviewPolicy === "string" && VALID_LOCAL_REVIEW_POLICIES.has(raw.localReviewPolicy as LocalReviewPolicy)
+        ? (raw.localReviewPolicy as LocalReviewPolicy)
+        : "block_ready",
     reviewBotLogins: Array.isArray(raw.reviewBotLogins)
       ? raw.reviewBotLogins
           .filter((value): value is string => typeof value === "string" && value.trim() !== "")

--- a/src/core/local-review.ts
+++ b/src/core/local-review.ts
@@ -234,7 +234,11 @@ export function shouldRunLocalReview(
   record: { local_review_head_sha: string | null },
   pr: GitHubPullRequest,
 ): boolean {
-  return config.localReviewEnabled && pr.isDraft && record.local_review_head_sha !== pr.headRefOid;
+  return (
+    config.localReviewEnabled &&
+    record.local_review_head_sha !== pr.headRefOid &&
+    (pr.isDraft || config.localReviewPolicy === "block_merge")
+  );
 }
 
 function buildLocalReviewPrompt(args: {

--- a/src/core/supervisor.ts
+++ b/src/core/supervisor.ts
@@ -85,6 +85,7 @@ function localReviewHighSeverityNeedsFix(
   pr: Pick<GitHubPullRequest, "headRefOid">,
 ): boolean {
   return (
+    config.localReviewEnabled &&
     config.localReviewPolicy !== "advisory" &&
     record.local_review_head_sha === pr.headRefOid &&
     record.local_review_verified_max_severity === "high"
@@ -647,6 +648,7 @@ export function localReviewBlocksReady(
   pr: Pick<GitHubPullRequest, "headRefOid" | "isDraft">,
 ): boolean {
   return (
+    config.localReviewEnabled &&
     pr.isDraft &&
     config.localReviewPolicy === "block_ready" &&
     record.local_review_head_sha === pr.headRefOid &&
@@ -671,6 +673,7 @@ function localReviewBlocksMerge(
   pr: Pick<GitHubPullRequest, "headRefOid" | "isDraft">,
 ): boolean {
   return (
+    config.localReviewEnabled &&
     !pr.isDraft &&
     config.localReviewPolicy === "block_merge" &&
     record.local_review_head_sha === pr.headRefOid &&

--- a/src/core/supervisor.ts
+++ b/src/core/supervisor.ts
@@ -80,10 +80,15 @@ function createIssueRecord(config: SupervisorConfig, issueNumber: number): Issue
 }
 
 function localReviewHighSeverityNeedsFix(
+  config: SupervisorConfig,
   record: Pick<IssueRunRecord, "local_review_head_sha" | "local_review_verified_max_severity">,
   pr: Pick<GitHubPullRequest, "headRefOid">,
 ): boolean {
-  return record.local_review_head_sha === pr.headRefOid && record.local_review_verified_max_severity === "high";
+  return (
+    config.localReviewPolicy !== "advisory" &&
+    record.local_review_head_sha === pr.headRefOid &&
+    record.local_review_verified_max_severity === "high"
+  );
 }
 
 function localReviewRetryLoopCandidate(
@@ -95,7 +100,7 @@ function localReviewRetryLoopCandidate(
 ): boolean {
   const checkSummary = summarizeChecks(checks);
   return (
-    localReviewHighSeverityNeedsFix(record, pr) &&
+    localReviewHighSeverityNeedsFix(config, record, pr) &&
     !checkSummary.hasFailing &&
     !checkSummary.hasPending &&
     configuredBotReviewThreads(config, reviewThreads).length === 0 &&
@@ -631,6 +636,7 @@ function mergeConditionsSatisfied(pr: GitHubPullRequest, checks: PullRequestChec
 }
 
 export function localReviewBlocksReady(
+  config: SupervisorConfig,
   record: Pick<
     IssueRunRecord,
     | "local_review_head_sha"
@@ -638,9 +644,35 @@ export function localReviewBlocksReady(
     | "local_review_recommendation"
     | "local_review_degraded"
   > & { local_review_verified_max_severity?: IssueRunRecord["local_review_verified_max_severity"] },
-  pr: Pick<GitHubPullRequest, "headRefOid">,
+  pr: Pick<GitHubPullRequest, "headRefOid" | "isDraft">,
 ): boolean {
   return (
+    pr.isDraft &&
+    config.localReviewPolicy === "block_ready" &&
+    record.local_review_head_sha === pr.headRefOid &&
+    (
+      (record.local_review_verified_max_severity === "high" && record.local_review_findings_count > 0) ||
+      record.local_review_recommendation !== "ready" ||
+      record.local_review_findings_count > 0 ||
+      Boolean(record.local_review_degraded)
+    )
+  );
+}
+
+function localReviewBlocksMerge(
+  config: SupervisorConfig,
+  record: Pick<
+    IssueRunRecord,
+    | "local_review_head_sha"
+    | "local_review_findings_count"
+    | "local_review_recommendation"
+    | "local_review_degraded"
+  > & { local_review_verified_max_severity?: IssueRunRecord["local_review_verified_max_severity"] },
+  pr: Pick<GitHubPullRequest, "headRefOid" | "isDraft">,
+): boolean {
+  return (
+    !pr.isDraft &&
+    config.localReviewPolicy === "block_merge" &&
     record.local_review_head_sha === pr.headRefOid &&
     (
       (record.local_review_verified_max_severity === "high" && record.local_review_findings_count > 0) ||
@@ -735,7 +767,7 @@ export function inferStateFromPullRequest(
     return "blocked";
   }
 
-  if (localReviewHighSeverityNeedsFix(record, pr)) {
+  if (localReviewHighSeverityNeedsFix(config, record, pr)) {
     return "local_review_fix";
   }
 
@@ -764,7 +796,7 @@ export function inferStateFromPullRequest(
     return "draft_pr";
   }
 
-  if (localReviewBlocksReady(record, pr)) {
+  if (localReviewBlocksReady(config, record, pr) || localReviewBlocksMerge(config, record, pr)) {
     return "pr_open";
   }
 
@@ -1000,6 +1032,7 @@ function localReviewHeadDetails(
 }
 
 function localReviewIsGating(
+  config: SupervisorConfig,
   record: Pick<
     IssueRunRecord,
     | "local_review_head_sha"
@@ -1014,7 +1047,7 @@ function localReviewIsGating(
     return false;
   }
 
-  return localReviewBlocksReady(record, pr);
+  return localReviewBlocksReady(config, record, pr) || localReviewBlocksMerge(config, record, pr);
 }
 
 export function formatDetailedStatus(args: {
@@ -1037,7 +1070,7 @@ export function formatDetailedStatus(args: {
   }
 
   const localReviewHead = localReviewHeadDetails(activeRecord, pr);
-  const localReviewGating = localReviewIsGating(activeRecord, pr) ? "yes" : "no";
+  const localReviewGating = localReviewIsGating(config, activeRecord, pr) ? "yes" : "no";
   const localReviewStalled =
     pr && localReviewRetryLoopStalled(config, activeRecord, pr, checks, reviewThreads) ? "yes" : "no";
   const lines = [
@@ -1052,7 +1085,7 @@ export function formatDetailedStatus(args: {
     `last_failure_kind=${activeRecord.last_failure_kind ?? "none"}`,
     `last_failure_signature=${activeRecord.last_failure_signature ?? "none"}`,
     `retries timeout=${activeRecord.timeout_retry_count} verification=${activeRecord.blocked_verification_retry_count} same_blocker=${activeRecord.repeated_blocker_count} same_failure_signature=${activeRecord.repeated_failure_signature_count}`,
-    `local_review gating=${localReviewGating} findings=${activeRecord.local_review_findings_count} root_causes=${activeRecord.local_review_root_cause_count} max_severity=${activeRecord.local_review_max_severity ?? "none"} verified_findings=${activeRecord.local_review_verified_findings_count} verified_max_severity=${activeRecord.local_review_verified_max_severity ?? "none"} recommendation=${activeRecord.local_review_recommendation ?? "none"} degraded=${activeRecord.local_review_degraded ? "yes" : "no"} head=${localReviewHead.status} reviewed_head_sha=${localReviewHead.reviewedHeadSha} pr_head_sha=${localReviewHead.prHeadSha} ran_at=${activeRecord.local_review_run_at ?? "none"} signature=${activeRecord.last_local_review_signature ?? "none"} repeated=${activeRecord.repeated_local_review_signature_count} stalled=${localReviewStalled}`,
+    `local_review gating=${localReviewGating} policy=${config.localReviewPolicy} findings=${activeRecord.local_review_findings_count} root_causes=${activeRecord.local_review_root_cause_count} max_severity=${activeRecord.local_review_max_severity ?? "none"} verified_findings=${activeRecord.local_review_verified_findings_count} verified_max_severity=${activeRecord.local_review_verified_max_severity ?? "none"} recommendation=${activeRecord.local_review_recommendation ?? "none"} degraded=${activeRecord.local_review_degraded ? "yes" : "no"} head=${localReviewHead.status} reviewed_head_sha=${localReviewHead.reviewedHeadSha} pr_head_sha=${localReviewHead.prHeadSha} ran_at=${activeRecord.local_review_run_at ?? "none"} signature=${activeRecord.last_local_review_signature ?? "none"} repeated=${activeRecord.repeated_local_review_signature_count} stalled=${localReviewStalled}`,
   ];
 
   if (activeRecord.last_error) {
@@ -2150,7 +2183,7 @@ export class Supervisor {
           const signatureTracking = nextLocalReviewSignatureTracking(record, refreshedPr.headRefOid, actionableSignature);
 
           record = this.stateStore.touch(record, {
-            state: "draft_pr",
+            state: refreshedPr.isDraft ? "draft_pr" : "pr_open",
             local_review_head_sha: refreshedPr.headRefOid,
             local_review_summary_path: localReview.summaryPath,
             local_review_run_at: localReview.ranAt,
@@ -2168,12 +2201,16 @@ export class Supervisor {
                 : null,
             last_error:
               localReview.recommendation !== "ready"
-                ? truncate(
+                  ? truncate(
                     localReview.degraded
-                      ? "Local review completed in a degraded state. PR will remain draft until local review succeeds cleanly."
+                      ? refreshedPr.isDraft
+                        ? "Local review completed in a degraded state. PR will remain draft until local review succeeds cleanly."
+                        : "Local review completed in a degraded state. Merge remains gated until local review succeeds cleanly on the current head."
                       : localReview.verifiedMaxSeverity === "high"
                         ? `Local review found verified high-severity findings (${localReview.findingsCount} actionable findings across ${localReview.rootCauseCount} root cause(s)). A local_review_fix repair pass is required.`
-                        : `Local review requested changes (${localReview.findingsCount} actionable findings across ${localReview.rootCauseCount} root cause(s)). PR will remain draft until the branch is updated and re-reviewed.`,
+                        : refreshedPr.isDraft
+                          ? `Local review requested changes (${localReview.findingsCount} actionable findings across ${localReview.rootCauseCount} root cause(s)). PR will remain draft until the branch is updated and re-reviewed.`
+                          : `Local review requested changes (${localReview.findingsCount} actionable findings across ${localReview.rootCauseCount} root cause(s)). Merge remains gated until the current head is updated and re-reviewed.`,
                     500,
                   )
                 : null,
@@ -2181,7 +2218,7 @@ export class Supervisor {
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           record = this.stateStore.touch(record, {
-            state: "draft_pr",
+            state: refreshedPr.isDraft ? "draft_pr" : "pr_open",
             local_review_head_sha: refreshedPr.headRefOid,
             local_review_summary_path: null,
             local_review_run_at: nowIso(),
@@ -2225,7 +2262,7 @@ export class Supervisor {
         configuredBotReviewThreads(this.config, refreshedReviewThreads).length === 0 &&
         (!this.config.humanReviewBlocksMerge || manualReviewThreads(this.config, refreshedReviewThreads).length === 0) &&
         !mergeConflictDetected(refreshedPr) &&
-        !localReviewBlocksReady(record, refreshedPr) &&
+        !localReviewBlocksReady(this.config, record, refreshedPr) &&
         !options.dryRun
       ) {
         await this.github.markPullRequestReady(refreshedPr.number);
@@ -2244,7 +2281,7 @@ export class Supervisor {
       const localReviewFailureContextForState =
         nextState === "blocked" && localReviewRetryLoopStalled(this.config, record, postReadyPr, postReadyChecks, postReadyReviewThreads)
           ? localReviewStallFailureContext(record)
-          : nextState === "local_review_fix" && localReviewHighSeverityNeedsFix(record, postReadyPr)
+          : nextState === "local_review_fix" && localReviewHighSeverityNeedsFix(this.config, record, postReadyPr)
             ? localReviewFailureContext(record)
             : null;
       const effectiveFailureContext = refreshedFailureContext ?? localReviewFailureContextForState;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,7 @@ export type AgentCategory =
   | "artistry";
 
 export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh";
+export type LocalReviewPolicy = "advisory" | "block_ready" | "block_merge";
 
 export interface SupervisorConfig {
   repoPath: string;
@@ -53,6 +54,7 @@ export interface SupervisorConfig {
   localReviewRoles: string[];
   localReviewArtifactDir: string;
   localReviewConfidenceThreshold: number;
+  localReviewPolicy: LocalReviewPolicy;
   reviewBotLogins: string[];
   humanReviewBlocksMerge: boolean;
   issueJournalRelativePath: string;

--- a/test/agent-policy.test.ts
+++ b/test/agent-policy.test.ts
@@ -22,6 +22,7 @@ function makeConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig
     reasoningEscalateOnRepeatedFailure: true,
     sharedMemoryFiles: [],
     localReviewEnabled: false,
+    localReviewPolicy: "block_ready",
     localReviewRoles: ["reviewer"],
     localReviewArtifactDir: "/tmp/reviews",
     localReviewConfidenceThreshold: 0.7,

--- a/test/check-cancellation.test.ts
+++ b/test/check-cancellation.test.ts
@@ -20,6 +20,7 @@ function makeConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig
     gsdInstallScope: "global",
     gsdPlanningFiles: [],
     localReviewEnabled: false,
+    localReviewPolicy: "block_ready",
     localReviewRoles: ["reviewer"],
     localReviewArtifactDir: "/tmp/reviews",
     localReviewConfidenceThreshold: 0.7,

--- a/test/done-workspace-cleanup.test.ts
+++ b/test/done-workspace-cleanup.test.ts
@@ -22,6 +22,7 @@ function makeConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig
     reasoningEscalateOnRepeatedFailure: true,
     sharedMemoryFiles: [],
     localReviewEnabled: false,
+    localReviewPolicy: "block_ready",
     localReviewRoles: ["reviewer"],
     localReviewArtifactDir: "/tmp/reviews",
     localReviewConfidenceThreshold: 0.7,

--- a/test/handoff-missing-retry.test.ts
+++ b/test/handoff-missing-retry.test.ts
@@ -20,6 +20,7 @@ function makeConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig
     gsdInstallScope: "global",
     gsdPlanningFiles: [],
     localReviewEnabled: false,
+    localReviewPolicy: "block_ready",
     localReviewRoles: ["reviewer"],
     localReviewArtifactDir: "/tmp/reviews",
     localReviewConfidenceThreshold: 0.7,

--- a/test/hardening-parity.test.ts
+++ b/test/hardening-parity.test.ts
@@ -221,3 +221,43 @@ test("loadConfig keeps valid localReviewConfidenceThreshold and falls back for i
     },
   );
 });
+
+test("loadConfig defaults localReviewPolicy to block_ready", async () => {
+  await withTempConfig(
+    JSON.stringify(BASE_CONFIG),
+    (configPath) => {
+      const config = loadConfig(configPath) as unknown as {
+        localReviewPolicy: string;
+      };
+      assert.equal(config.localReviewPolicy, "block_ready");
+    },
+  );
+});
+
+test("loadConfig keeps valid localReviewPolicy and falls back for invalid values", async () => {
+  await withTempConfig(
+    JSON.stringify({
+      ...BASE_CONFIG,
+      localReviewPolicy: "block_merge",
+    }),
+    (configPath) => {
+      const config = loadConfig(configPath) as unknown as {
+        localReviewPolicy: string;
+      };
+      assert.equal(config.localReviewPolicy, "block_merge");
+    },
+  );
+
+  await withTempConfig(
+    JSON.stringify({
+      ...BASE_CONFIG,
+      localReviewPolicy: "not-a-policy",
+    }),
+    (configPath) => {
+      const config = loadConfig(configPath) as unknown as {
+        localReviewPolicy: string;
+      };
+      assert.equal(config.localReviewPolicy, "block_ready");
+    },
+  );
+});

--- a/test/local-review-fix-parity.test.ts
+++ b/test/local-review-fix-parity.test.ts
@@ -23,6 +23,7 @@ function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConf
     gsdCodexConfigDir: undefined,
     gsdPlanningFiles: ["PROJECT.md", "REQUIREMENTS.md", "ROADMAP.md", "STATE.md"],
     localReviewEnabled: true,
+    localReviewPolicy: "block_ready",
     localReviewRoles: ["reviewer"],
     localReviewArtifactDir: "/tmp/reviews",
     localReviewConfidenceThreshold: 0.7,

--- a/test/local-review-gating.test.ts
+++ b/test/local-review-gating.test.ts
@@ -192,3 +192,21 @@ test("inferStateFromPullRequest does not treat stale ready-PR review data as fre
 
   assert.equal(inferStateFromPullRequest(createConfig({ localReviewPolicy: "block_merge" }), record, pr, [], []), "ready_to_merge");
 });
+
+test("disabled local review suppresses stale local-review-driven gating and retry states", () => {
+  const config = createConfig({ localReviewEnabled: false, localReviewPolicy: "block_merge" });
+  const record = createRecord({
+    local_review_head_sha: "head456",
+    local_review_findings_count: 2,
+    local_review_recommendation: "changes_requested",
+    local_review_verified_max_severity: "high",
+    local_review_verified_findings_count: 1,
+    repeated_local_review_signature_count: config.sameFailureSignatureRepeatLimit,
+  });
+  const readyPr = createPullRequest({ isDraft: false, headRefOid: "head456" });
+  const draftPr = createPullRequest({ isDraft: true, headRefOid: "head456" });
+
+  assert.equal(localReviewBlocksReady(config, record, draftPr), false);
+  assert.equal(inferStateFromPullRequest(config, record, readyPr, [], []), "ready_to_merge");
+  assert.equal(inferStateFromPullRequest(config, record, draftPr, [], []), "draft_pr");
+});

--- a/test/local-review-gating.test.ts
+++ b/test/local-review-gating.test.ts
@@ -1,9 +1,116 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { localReviewBlocksReady } from "../src/core/supervisor";
+import { localReviewBlocksReady, inferStateFromPullRequest } from "../src/core/supervisor";
+import { shouldRunLocalReview } from "../src/core/local-review";
+import { GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "../src/types";
+
+function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return {
+    repoPath: "/tmp/repo",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "/tmp/workspaces",
+    stateBackend: "json",
+    stateFile: "/tmp/state.json",
+    agentCategoryByState: {},
+    reasoningEffortByState: {},
+    reasoningEscalateOnRepeatedFailure: true,
+    sharedMemoryFiles: [],
+    gsdEnabled: false,
+    gsdAutoInstall: false,
+    gsdInstallScope: "global",
+    gsdPlanningFiles: [],
+    localReviewEnabled: true,
+    localReviewRoles: ["reviewer"],
+    localReviewArtifactDir: "/tmp/reviews",
+    localReviewConfidenceThreshold: 0.7,
+    localReviewPolicy: "block_ready",
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+    humanReviewBlocksMerge: true,
+    issueJournalRelativePath: ".opencode-supervisor/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    skipTitlePrefixes: [],
+    branchPrefix: "opencode/issue-",
+    pollIntervalSeconds: 120,
+    copilotReviewWaitMinutes: 0,
+    agentExecTimeoutMinutes: 30,
+    maxAgentAttemptsPerIssue: 30,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+    ...overrides,
+  };
+}
+
+function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
+  return {
+    issue_number: 44,
+    state: "pr_open",
+    branch: "opencode/issue-44",
+    pr_number: 12,
+    workspace: "/tmp/workspaces/issue-44",
+    journal_path: "/tmp/workspaces/issue-44/.opencode-supervisor/issue-journal.md",
+    review_wait_started_at: null,
+    review_wait_head_sha: null,
+    agent_session_id: null,
+    local_review_head_sha: "head123",
+    local_review_summary_path: "/tmp/reviews/head123.md",
+    local_review_run_at: "2026-03-12T00:00:00Z",
+    local_review_max_severity: "medium",
+    local_review_findings_count: 1,
+    local_review_root_cause_count: 1,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: "changes_requested",
+    local_review_degraded: false,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    attempt_count: 1,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+    last_head_sha: "head123",
+    last_agent_summary: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: null,
+    blocked_reason: null,
+    processed_review_thread_ids: [],
+    updated_at: "2026-03-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
+  return {
+    number: 12,
+    title: "Test PR",
+    url: "https://example.test/pr/12",
+    state: "OPEN",
+    createdAt: "2026-03-12T00:00:00Z",
+    updatedAt: "2026-03-12T00:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "opencode/issue-44",
+    headRefOid: "head456",
+    mergedAt: null,
+    ...overrides,
+  };
+}
 
 test("localReviewBlocksReady blocks when recommendation is not ready on current head", () => {
   const blocked = localReviewBlocksReady(
+    createConfig(),
     {
       local_review_head_sha: "abc123",
       local_review_findings_count: 0,
@@ -11,6 +118,7 @@ test("localReviewBlocksReady blocks when recommendation is not ready on current 
     },
     {
       headRefOid: "abc123",
+      isDraft: true,
     },
   );
 
@@ -19,6 +127,7 @@ test("localReviewBlocksReady blocks when recommendation is not ready on current 
 
 test("localReviewBlocksReady does not block when recommendation is ready with zero findings", () => {
   const blocked = localReviewBlocksReady(
+    createConfig(),
     {
       local_review_head_sha: "abc123",
       local_review_findings_count: 0,
@@ -26,6 +135,7 @@ test("localReviewBlocksReady does not block when recommendation is ready with ze
     },
     {
       headRefOid: "abc123",
+      isDraft: true,
     },
   );
 
@@ -34,6 +144,7 @@ test("localReviewBlocksReady does not block when recommendation is ready with ze
 
 test("localReviewBlocksReady does not block on verified severity alone when current findings are zero", () => {
   const blocked = localReviewBlocksReady(
+    createConfig(),
     {
       local_review_head_sha: "abc123",
       local_review_findings_count: 0,
@@ -42,8 +153,42 @@ test("localReviewBlocksReady does not block on verified severity alone when curr
     },
     {
       headRefOid: "abc123",
+      isDraft: true,
     },
   );
 
   assert.equal(blocked, false);
+});
+
+test("shouldRunLocalReview reruns for ready PR head updates only in block_merge mode", () => {
+  const pr = createPullRequest({ isDraft: false, headRefOid: "newhead" });
+  const record = { local_review_head_sha: "oldhead" };
+
+  assert.equal(shouldRunLocalReview(createConfig({ localReviewPolicy: "block_merge" }), record, pr), true);
+  assert.equal(shouldRunLocalReview(createConfig({ localReviewPolicy: "block_ready" }), record, pr), false);
+  assert.equal(shouldRunLocalReview(createConfig({ localReviewPolicy: "advisory" }), record, pr), false);
+});
+
+test("inferStateFromPullRequest blocks merge for current-head findings only in block_merge mode", () => {
+  const record = createRecord({
+    local_review_head_sha: "head456",
+    local_review_findings_count: 1,
+    local_review_recommendation: "changes_requested",
+  });
+  const pr = createPullRequest({ isDraft: false, headRefOid: "head456" });
+
+  assert.equal(inferStateFromPullRequest(createConfig({ localReviewPolicy: "block_merge" }), record, pr, [], []), "pr_open");
+  assert.equal(inferStateFromPullRequest(createConfig({ localReviewPolicy: "block_ready" }), record, pr, [], []), "ready_to_merge");
+  assert.equal(inferStateFromPullRequest(createConfig({ localReviewPolicy: "advisory" }), record, pr, [], []), "ready_to_merge");
+});
+
+test("inferStateFromPullRequest does not treat stale ready-PR review data as freshly gated", () => {
+  const record = createRecord({
+    local_review_head_sha: "oldhead",
+    local_review_findings_count: 1,
+    local_review_recommendation: "changes_requested",
+  });
+  const pr = createPullRequest({ isDraft: false, headRefOid: "newhead" });
+
+  assert.equal(inferStateFromPullRequest(createConfig({ localReviewPolicy: "block_merge" }), record, pr, [], []), "ready_to_merge");
 });

--- a/test/local-review-role-detection.test.ts
+++ b/test/local-review-role-detection.test.ts
@@ -23,6 +23,7 @@ function makeConfig(repoPath: string, artifactDir: string, tempDir: string): Sup
     gsdInstallScope: "global",
     gsdPlanningFiles: ["PROJECT.md", "REQUIREMENTS.md", "ROADMAP.md", "STATE.md"],
     localReviewEnabled: true,
+    localReviewPolicy: "block_ready",
     localReviewRoles: [],
     localReviewArtifactDir: artifactDir,
     localReviewConfidenceThreshold: 0.7,

--- a/test/local-review-threshold.test.ts
+++ b/test/local-review-threshold.test.ts
@@ -23,6 +23,7 @@ function makeConfig(artifactDir: string): SupervisorConfig {
     gsdInstallScope: "global",
     gsdPlanningFiles: ["PROJECT.md", "REQUIREMENTS.md", "ROADMAP.md", "STATE.md"],
     localReviewEnabled: true,
+    localReviewPolicy: "block_ready",
     localReviewRoles: ["reviewer"],
     localReviewArtifactDir: artifactDir,
     localReviewConfidenceThreshold: 0.7,

--- a/test/status-diagnostics.test.ts
+++ b/test/status-diagnostics.test.ts
@@ -172,7 +172,7 @@ test("status output falls back to an informative readiness warning", async () =>
 });
 
 test("formatDetailedStatus shows stale local-review head details for merge gating", async () => {
-  await withTempSupervisor({ localReviewPolicy: "block_merge" }, async (supervisor) => {
+  await withTempSupervisor({ localReviewEnabled: true, localReviewPolicy: "block_merge" }, async (supervisor) => {
     const output = formatDetailedStatus({
       config: supervisor.config,
       activeRecord: createRecord(supervisor.config, {
@@ -200,7 +200,7 @@ test("formatDetailedStatus shows stale local-review head details for merge gatin
 });
 
 test("formatDetailedStatus shows current gating review and repeat-loop state", async () => {
-  await withTempSupervisor({ localReviewPolicy: "block_merge" }, async (supervisor) => {
+  await withTempSupervisor({ localReviewEnabled: true, localReviewPolicy: "block_merge" }, async (supervisor) => {
     const repeatedCount = supervisor.config.sameFailureSignatureRepeatLimit;
     const output = formatDetailedStatus({
       config: supervisor.config,

--- a/test/status-diagnostics.test.ts
+++ b/test/status-diagnostics.test.ts
@@ -171,8 +171,8 @@ test("status output falls back to an informative readiness warning", async () =>
   });
 });
 
-test("formatDetailedStatus shows stale local-review head details", async () => {
-  await withTempSupervisor({}, async (supervisor) => {
+test("formatDetailedStatus shows stale local-review head details for merge gating", async () => {
+  await withTempSupervisor({ localReviewPolicy: "block_merge" }, async (supervisor) => {
     const output = formatDetailedStatus({
       config: supervisor.config,
       activeRecord: createRecord(supervisor.config, {
@@ -193,14 +193,14 @@ test("formatDetailedStatus shows stale local-review head details", async () => {
       reviewThreads: [],
     });
 
-    assert.match(output, /local_review gating=no /);
+    assert.match(output, /local_review gating=no policy=block_merge /);
     assert.match(output, /head=stale reviewed_head_sha=reviewed-sha pr_head_sha=current-pr-sha/);
     assert.match(output, /stalled=no/);
   });
 });
 
 test("formatDetailedStatus shows current gating review and repeat-loop state", async () => {
-  await withTempSupervisor({}, async (supervisor) => {
+  await withTempSupervisor({ localReviewPolicy: "block_merge" }, async (supervisor) => {
     const repeatedCount = supervisor.config.sameFailureSignatureRepeatLimit;
     const output = formatDetailedStatus({
       config: supervisor.config,
@@ -223,7 +223,7 @@ test("formatDetailedStatus shows current gating review and repeat-loop state", a
       reviewThreads: [],
     });
 
-    assert.match(output, /local_review gating=yes /);
+    assert.match(output, /local_review gating=yes policy=block_merge /);
     assert.match(output, /head=current reviewed_head_sha=current-pr-sha pr_head_sha=current-pr-sha/);
     assert.match(output, new RegExp(`repeated=${repeatedCount}`));
     assert.match(output, /stalled=yes/);


### PR DESCRIPTION
Closes #26
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented merge-gated local-review parity and committed it as `76d0736` (`Add merge-gated local review parity`).

Key changes:
- Added `localReviewPolicy` config support with `advisory`, `block_ready`, and `block_merge` in [src/types/index.ts](/tmp/codex-supervisor-opencode-workspaces/issue-26/src/types/index.ts) and [src/core/config.ts](/tmp/codex-supervisor-opencode-workspaces/issue-26/src/core/config.ts).
- Updated [src/core/local-review.ts](/tmp/codex-supervisor-opencode-workspaces/issue-26/src/core/local-review.ts) so ready PR head updates rerun local review only for `block_merge`.
- Updated [src/core/supervisor.ts](/tmp/codex-supervisor-opencode-workspaces/issue-26/src/core/supervisor.ts) so `block_ready` only gates drafts, `block_merge` gates ready PRs on the current reviewed head, stale review heads stop gating, and status output includes the active policy.
- Added focused coverage in [test/local-review-gating.test.ts](/tmp/codex-supervisor-opencode-workspaces/issue-26/test/local-review-gating.test.ts), [test/status-diagnostics.test.ts](/tmp/codex-supervisor-opencode-workspaces/issue-26/test/status-diagnostics.test.ts), and [test/hardening-parity.test.ts](/tmp/codex-supervisor-opencode-workspaces/issue-26/test/hardening-parity.test.ts), plus fixture updates in the other local-review test files.

Verification:
- `pnpm test -- test/local-review-gating.test.ts test/status-diagnostics.test.ts test/hardening-parity.test.ts test/local-review-fix-parity.test.ts test/loc...